### PR TITLE
Feat/flatten api templates

### DIFF
--- a/inst/include/ProcessAPI.h
+++ b/inst/include/ProcessAPI.h
@@ -34,11 +34,11 @@ public:
         const std::string&,
         const std::vector<size_t>&,
         std::vector<double>&) const;
-    template<class TIndex>
-    void schedule(const std::string&, const TIndex&, double);
-    individual_index_t get_scheduled(const std::string&) const;
-    template<class TIndex>
-    void clear_schedule(const std::string&, const TIndex&);
+    virtual void schedule(const std::string&, const individual_index_t&, double);
+    virtual void schedule(const std::string&, const std::vector<size_t>&, double);
+    virtual individual_index_t get_scheduled(const std::string&) const;
+    virtual void clear_schedule(const std::string&, const individual_index_t&);
+    virtual void clear_schedule(const std::string&, const std::vector<size_t>&);
     virtual void render(const std::string&, double, size_t);
     virtual void render(const std::string&, double);
     virtual size_t get_timestep() const;
@@ -113,10 +113,16 @@ inline void ProcessAPI::get_variable(
     state->get_variable(individual, variable, index, result);
 }
 
-template<class TIndex>
 inline void ProcessAPI::schedule(
     const std::string& event,
-    const TIndex& index,
+    const individual_index_t& index,
+    double delay) {
+    scheduler->schedule(event, index, delay);
+}
+
+inline void ProcessAPI::schedule(
+    const std::string& event,
+    const std::vector<size_t>& index,
     double delay) {
     scheduler->schedule(event, index, delay);
 }
@@ -125,10 +131,15 @@ inline individual_index_t ProcessAPI::get_scheduled(const std::string& event) co
     return scheduler->get_scheduled(event);
 }
 
-template<class TIndex>
 inline void ProcessAPI::clear_schedule(
     const std::string& event,
-    const TIndex& index) {
+    const individual_index_t& index) {
+    scheduler->clear_schedule(event, index);
+}
+
+inline void ProcessAPI::clear_schedule(
+    const std::string& event,
+    const std::vector<size_t>& index) {
     scheduler->clear_schedule(event, index);
 }
 


### PR DESCRIPTION
Template methods are difficult to mock :(

Most mocking in C++ is done using inheritance. But you can't have virtual templated methods (How does the inheritance part of C++ know how many entries to put in the virtual lookup table? It knows nothing about templates).

An alternative way around is to [template the production function](https://stackoverflow.com/questions/5777733/mock-non-virtual-method-c-gmock). But in our IBMs, process functions are lambdas. Templating lambdas is C++20.

So, this PR removes templated methods from the api