### PR TITLE
implement querying number of individuals in a state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ docs/
 *.dll
 /Debug/
 .Rproj.user
+*.Rproj
+.vscode/

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -55,6 +55,10 @@ process_get_state <- function(api, individual, states) {
     .Call(`_individual_process_get_state`, api, individual, states)
 }
 
+process_get_state_size <- function(api, individual, states) {
+    .Call(`_individual_process_get_state_size`, api, individual, states)
+}
+
 process_get_variable <- function(api, individual, variable) {
     .Call(`_individual_process_get_variable`, api, individual, variable)
 }

--- a/R/api.R
+++ b/R/api.R
@@ -16,6 +16,14 @@ SimAPI <- R6::R6Class(
       state_names <- vcapply(unlist(list(...)), function(s) s$name)
       process_get_state(private$.api, individual$name, state_names)
     },
+
+    #' @description Get the number of individuals with a particular state
+    #' @param individual of interest
+    #' @param ... the states of interest
+    get_state_size = function(individual, ...) {
+      state_names <- vcapply(unlist(list(...)), function(s) s$name)
+      process_get_state_size(private$.api, individual$name, state_names)
+    },
     
     #' @description Get a variable vector for an individual
     #' @param individual the individual of interest

--- a/inst/include/ProcessAPI.h
+++ b/inst/include/ProcessAPI.h
@@ -28,6 +28,7 @@ private:
 public:
     ProcessAPI(Rcpp::XPtr<State>, Rcpp::XPtr<scheduler_t>, Rcpp::List, Rcpp::Environment);
     virtual const individual_index_t& get_state(const std::string&, const std::string&) const;
+    virtual const size_t get_state_size(const std::string&, const std::string&) const;
     virtual const variable_vector_t& get_variable(const std::string&, const std::string&) const;
     virtual void get_variable(
         const std::string&,
@@ -102,6 +103,12 @@ inline const individual_index_t& ProcessAPI::get_state(
     const std::string& individual,
     const std::string& state_name) const {
     return state->get_state(individual, state_name);
+}
+
+inline const size_t ProcessAPI::get_state_size(
+    const std::string& individual,
+    const std::string& state_name) const {
+    return state->get_state_size(individual, state_name);
 }
 
 inline const variable_vector_t& ProcessAPI::get_variable(

--- a/inst/include/State.h
+++ b/inst/include/State.h
@@ -43,6 +43,7 @@ public:
      * Reading the state
      */
     const individual_index_t& get_state(const std::string&, const std::string&) const;
+    const size_t get_state_size(const std::string&, const std::string&) const;
     const variable_vector_t& get_variable(const std::string&, const std::string&) const;
     void get_variable(
         const std::string&,
@@ -175,6 +176,17 @@ inline const individual_index_t& State::get_state(
     }
     return individual_states.at(state_name);
 }
+
+inline const size_t State::get_state_size(
+    const std::string& individual,
+    const std::string& state_name
+) const {
+    const auto& individual_states = states.at(individual);
+    if (individual_states.find(state_name) == individual_states.end()) {
+        Rcpp::stop("Unknown state");
+    }
+    return individual_states.at(state_name).size();
+};
 
 inline const variable_vector_t& State::get_variable(
     const std::string& individual,

--- a/man/SimAPI.Rd
+++ b/man/SimAPI.Rd
@@ -15,6 +15,7 @@ The entry point for models to inspect and manipulate the simulation
 \subsection{Public methods}{
 \itemize{
 \item \href{#method-get_state}{\code{SimAPI$get_state()}}
+\item \href{#method-get_state_size}{\code{SimAPI$get_state_size()}}
 \item \href{#method-get_variable}{\code{SimAPI$get_variable()}}
 \item \href{#method-queue_state_update}{\code{SimAPI$queue_state_update()}}
 \item \href{#method-queue_variable_update}{\code{SimAPI$queue_variable_update()}}
@@ -35,6 +36,25 @@ The entry point for models to inspect and manipulate the simulation
 Get the index of individuals with a particular state
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{SimAPI$get_state(individual, ...)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{individual}}{of interest}
+
+\item{\code{...}}{the states of interest}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-get_state_size"></a>}}
+\if{latex}{\out{\hypertarget{method-get_state_size}{}}}
+\subsection{Method \code{get_state_size()}}{
+Get the number of individuals with a particular state
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{SimAPI$get_state_size(individual, ...)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -141,6 +141,19 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// process_get_state_size
+int process_get_state_size(Rcpp::XPtr<ProcessAPI> api, const std::string individual, const std::vector<std::string> states);
+RcppExport SEXP _individual_process_get_state_size(SEXP apiSEXP, SEXP individualSEXP, SEXP statesSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<ProcessAPI> >::type api(apiSEXP);
+    Rcpp::traits::input_parameter< const std::string >::type individual(individualSEXP);
+    Rcpp::traits::input_parameter< const std::vector<std::string> >::type states(statesSEXP);
+    rcpp_result_gen = Rcpp::wrap(process_get_state_size(api, individual, states));
+    return rcpp_result_gen;
+END_RCPP
+}
 // process_get_variable
 std::vector<double> process_get_variable(Rcpp::XPtr<ProcessAPI> api, const std::string individual, const std::string variable);
 RcppExport SEXP _individual_process_get_variable(SEXP apiSEXP, SEXP individualSEXP, SEXP variableSEXP) {
@@ -379,6 +392,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_individual_execute_process", (DL_FUNC) &_individual_execute_process, 2},
     {"_individual_create_process_api", (DL_FUNC) &_individual_create_process_api, 4},
     {"_individual_process_get_state", (DL_FUNC) &_individual_process_get_state, 3},
+    {"_individual_process_get_state_size", (DL_FUNC) &_individual_process_get_state_size, 3},
     {"_individual_process_get_variable", (DL_FUNC) &_individual_process_get_variable, 3},
     {"_individual_process_get_variable_at_index", (DL_FUNC) &_individual_process_get_variable_at_index, 4},
     {"_individual_process_queue_state_update", (DL_FUNC) &_individual_process_queue_state_update, 4},

--- a/src/process_api.cpp
+++ b/src/process_api.cpp
@@ -40,6 +40,19 @@ std::vector<size_t> process_get_state(
     return result;
 }
 
+// [[Rcpp::export]]
+int process_get_state_size(
+    Rcpp::XPtr<ProcessAPI> api,
+    const std::string individual,
+    const std::vector<std::string> states
+){
+    int result{0};
+    for (const auto& state : states) {
+        result += api->get_state_size(individual, state);
+    }
+    return result;
+}
+
 //[[Rcpp::export]]
 std::vector<double> process_get_variable(
     Rcpp::XPtr<ProcessAPI> api,


### PR DESCRIPTION
Hello MRC IDE team! I am creating a small pull request to add functionality addressing issue #38 
It exposes a new method `SimAPI$get_state_size` taking the same arguments as `SimAPI$get_state`, and the internal functions follow as closely as possible the logic from `process_get_state`.