### PR TITLE
Make event time start at 1

### DIFF
--- a/inst/include/Event.h
+++ b/inst/include/Event.h
@@ -29,7 +29,7 @@ inline std::vector<size_t> round_delay(const std::vector<double>& delay) {
 }
 
 struct EventBase {
-    size_t t = 0;
+    size_t t = 1;
 
     virtual void tick() {
         ++t;

--- a/tests/testthat/test-events.R
+++ b/tests/testthat/test-events.R
@@ -1,8 +1,24 @@
+test_that("first event is triggered at t=1", {
+  event <- Event$new()
+  listener <- mockery::mock()
+  event$add_listener(listener)
+  event$schedule(c(0, 1))
+
+  #time = 1
+  event$.process()
+  mockery::expect_args(listener, 1, t = 1)
+  event$.tick()
+
+  #time = 2
+  event$.process()
+  mockery::expect_args(listener, 2, t = 2)
+  event$.tick()
+})
+
 test_that("events can be scheduled for the future", {
   event <- Event$new()
   listener <- mockery::mock()
   event$add_listener(listener)
-  #time = 0
   event$schedule(c(2, 3))
 
   #time = 1
@@ -23,15 +39,14 @@ test_that("events can be scheduled for the future", {
   #time = 4
   event$.process()
   mockery::expect_called(listener, 2)
-  mockery::expect_args(listener, 1, t = 2)
-  mockery::expect_args(listener, 2, t = 3)
+  mockery::expect_args(listener, 1, t = 3)
+  mockery::expect_args(listener, 2, t = 4)
 })
 
 test_that("targeted events can be scheduled for the future", {
   event <- TargetedEvent$new(10)
   listener <- mockery::mock()
   event$add_listener(listener)
-  #time = 0
   event$schedule(c(2, 4), 2)
 
   #time = 1
@@ -52,14 +67,13 @@ test_that("targeted events can be scheduled for the future", {
   #time = 4
   event$.process()
   mockery::expect_called(listener, 1)
-  expect_targeted_listener(listener, 1, t = 2, target = c(2, 4))
+  expect_targeted_listener(listener, 1, t = 3, target = c(2, 4))
 })
 
 test_that("events can be scheduled for for a Real time", {
   event <- TargetedEvent$new(10)
   listener <- mockery::mock()
   event$add_listener(listener)
-  #time = 0
   event$schedule(c(2, 4), 1.9)
 
   #time = 1
@@ -80,14 +94,13 @@ test_that("events can be scheduled for for a Real time", {
   #time = 4
   event$.process()
   mockery::expect_called(listener, 1)
-  expect_targeted_listener(listener, 1, t = 2, target = c(2, 4))
+  expect_targeted_listener(listener, 1, t = 3, target = c(2, 4))
 })
 
 test_that("you can schedule different times for a target population", {
   event <- TargetedEvent$new(10)
   listener <- mockery::mock()
   event$add_listener(listener)
-  #time = 0
   event$schedule(c(1, 2, 4, 8, 3), c(1, 3, 1, 2, 2))
 
   #time = 1
@@ -98,19 +111,19 @@ test_that("you can schedule different times for a target population", {
   #time = 2
   event$.process()
   mockery::expect_called(listener, 1)
-  expect_targeted_listener(listener, 1, t = 1, target = c(1, 4))
+  expect_targeted_listener(listener, 1, t = 2, target = c(1, 4))
   event$.tick()
 
   #time = 3
   event$.process()
   mockery::expect_called(listener, 2)
-  expect_targeted_listener(listener, 2, t = 2, target = c(3, 8))
+  expect_targeted_listener(listener, 2, t = 3, target = c(3, 8))
   event$.tick()
 
   #time = 4
   event$.process()
   mockery::expect_called(listener, 3)
-  expect_targeted_listener(listener, 3, t = 3, target = 2)
+  expect_targeted_listener(listener, 3, t = 4, target = 2)
 })
 
 test_that("when you can schedule different times invalid times cause an error", {
@@ -132,7 +145,6 @@ test_that("you can see which individuals are scheduled for an event", {
   listener <- mockery::mock()
   event$add_listener(listener)
 
-  #time = 0
   expect_length(event$get_scheduled()$to_vector(), 0)
 
   #time = 1
@@ -165,7 +177,6 @@ test_that("multiple events can be scheduled", {
   event1$add_listener(listener1)
   event2$add_listener(listener2)
 
-  #time = 0
   expect_length(event1$get_scheduled()$to_vector(), 0)
   expect_length(event2$get_scheduled()$to_vector(), 0)
 
@@ -184,8 +195,8 @@ test_that("multiple events can be scheduled", {
 
   mockery::expect_called(listener1, 1)
   mockery::expect_called(listener2, 1)
-  expect_targeted_listener(listener1, 1, t = 1, target = c(2, 4))
-  expect_targeted_listener(listener2, 1, t = 1, target = c(1, 3))
+  expect_targeted_listener(listener1, 1, t = 2, target = c(2, 4))
+  expect_targeted_listener(listener2, 1, t = 2, target = c(1, 3))
 })
 
 test_that("events can be cleared for an individual", {
@@ -193,7 +204,6 @@ test_that("events can be cleared for an individual", {
   listener <- mockery::mock()
   event$add_listener(listener)
 
-  #time = 0
   expect_length(event$get_scheduled()$to_vector(), 0)
 
   #time = 1
@@ -207,5 +217,5 @@ test_that("events can be cleared for an individual", {
   expect_setequal(event$get_scheduled()$to_vector(), 2)
   event$.process()
   mockery::expect_called(listener, 1)
-  expect_targeted_listener(listener, 1, t = 1, target = 2)
+  expect_targeted_listener(listener, 1, t = 2, target = 2)
 })

--- a/tests/testthat/test-prefab.R
+++ b/tests/testthat/test-prefab.R
@@ -64,6 +64,6 @@ test_that("reschedule_listener schedules the correct update", {
   mockery::expect_called(followup_listener, 1)
   event$.tick()
   followup$.tick()
-  expect_targeted_listener(event_listener, 1, 2, target = c(2, 4))
-  expect_targeted_listener(followup_listener, 1, 3, target = c(2, 4))
+  expect_targeted_listener(event_listener, 1, 3, target = c(2, 4))
+  expect_targeted_listener(followup_listener, 1, 4, target = c(2, 4))
 })


### PR DESCRIPTION
Event listeners can be triggered with a timestep of 0. This fixes it