### PR TITLE
Ignore empty bitset updates

### DIFF
--- a/R/double_variable.R
+++ b/R/double_variable.R
@@ -55,7 +55,10 @@ DoubleVariable <- R6::R6Class(
             numeric(0)
           )
         }
-      } else if(is.numeric(index)) {
+      } else {
+        if (inherits(index, 'Bitset')) {
+          index <- index$to_vector()
+        }
         if (length(index) != 0) {
           double_variable_queue_update(
             self$.variable,
@@ -63,12 +66,6 @@ DoubleVariable <- R6::R6Class(
             index
           )
         }
-      } else if(!is.null(index$.bitset)) {
-        double_variable_queue_update(
-          self$.variable,
-          values,
-          index$to_vector()
-        )
       }
     },
 

--- a/tests/testthat/test-updates.R
+++ b/tests/testthat/test-updates.R
@@ -42,6 +42,19 @@ test_that("updating variables with an empty index is ignored", {
   expect_equal(after, 1:10)
 })
 
+test_that("updating variables with an empty bitset is ignored", {
+  size <- 10
+  sequence <- DoubleVariable$new(seq_len(size))
+
+  before <- sequence$get_values()
+  sequence$queue_update(11, Bitset$new(10))
+  sequence$.update()
+  after <- sequence$get_values()
+
+  expect_equal(before, 1:10)
+  expect_equal(after, 1:10)
+})
+
 test_that("updating variables with silly indices errors gracefully", {
   size <- 10
   sequence <- DoubleVariable$new(seq_len(size))


### PR DESCRIPTION
This does nothing

```r
my_variable$queue_update(3, numeric(0))
```

but this fills my_variable with 3

```r
my_variable$queue_update(3, Bitset$new(my_variable$size))
```

This commit adds a fix for that.