### PR TITLE
query number of individuals in set for all variable types

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -57,6 +57,10 @@ categorical_variable_get_index_of <- function(variable, values) {
     .Call(`_individual_categorical_variable_get_index_of`, variable, values)
 }
 
+categorical_variable_get_size_of <- function(variable, values) {
+    .Call(`_individual_categorical_variable_get_size_of`, variable, values)
+}
+
 categorical_variable_queue_update_vector <- function(variable, value, index) {
     invisible(.Call(`_individual_categorical_variable_queue_update_vector`, variable, value, index))
 }
@@ -79,6 +83,14 @@ double_variable_get_values_at_index <- function(variable, index) {
 
 double_variable_get_values_at_index_vector <- function(variable, index) {
     .Call(`_individual_double_variable_get_values_at_index_vector`, variable, index)
+}
+
+double_variable_get_index_of_range <- function(variable, a, b) {
+    .Call(`_individual_double_variable_get_index_of_range`, variable, a, b)
+}
+
+double_variable_get_size_of_range <- function(variable, a, b) {
+    .Call(`_individual_double_variable_get_size_of_range`, variable, a, b)
 }
 
 double_variable_queue_fill <- function(variable, value) {
@@ -171,6 +183,14 @@ integer_variable_get_index_of_set <- function(variable, values_set) {
 
 integer_variable_get_index_of_range <- function(variable, a, b) {
     .Call(`_individual_integer_variable_get_index_of_range`, variable, a, b)
+}
+
+integer_variable_get_size_of_set <- function(variable, values_set) {
+    .Call(`_individual_integer_variable_get_size_of_set`, variable, values_set)
+}
+
+integer_variable_get_size_of_range <- function(variable, a, b) {
+    .Call(`_individual_integer_variable_get_size_of_range`, variable, a, b)
 }
 
 integer_variable_queue_fill <- function(variable, value) {

--- a/R/categorical_variable.R
+++ b/R/categorical_variable.R
@@ -22,6 +22,12 @@ CategoricalVariable <- R6::R6Class(
       Bitset$new(from = categorical_variable_get_index_of(self$.variable, values))
     },
 
+    #' @description return the number of individuals with the given `values`
+    #' @param values the values to filter
+    get_size_of = function(values) {
+      categorical_variable_get_size_of(self$.variable, values)
+    },
+
     #' @description queue an update for this variable
     #' @param values the values to filter
     queue_update = function(value, index) {

--- a/R/double_variable.R
+++ b/R/double_variable.R
@@ -25,6 +25,24 @@ DoubleVariable <- R6::R6Class(
       double_variable_get_values_at_index(self$.variable, index$.bitset)
     },
 
+    #' @description return a bitset for individuals whose value lies in an interval
+    #' Search for indices corresponding to values in the interval [a,b].
+    #' @param a lower bound
+    #' @param b upper bound
+    get_index_of = function(a, b) {
+      stopifnot(a < b)
+      return(Bitset$new(from = double_variable_get_index_of_range(self$.variable, a, b)))            
+    },
+
+    #' @description return the number of individuals whose value lies in an interval
+    #' Count individuals whose value lies in the interval [a,b].
+    #' @param a lower bound
+    #' @param b upper bound
+    get_size_of = function(a, b) {
+      stopifnot(a < b)
+      double_variable_get_size_of_range(self$.variable, a, b)            
+    },
+
     #' @description Queue an update for a variable. There are 4 types of variable update:
     #'
     #' 1. Subset update. The index vector represents a subset of the variable to

--- a/R/integer_variable.R
+++ b/R/integer_variable.R
@@ -48,6 +48,23 @@ IntegerVariable <- R6::R6Class(
         stop("please provide a set of values to check, or both bounds of range [a,b]")        
     },
 
+    #' @description return the number of individuals with some subset of values
+    #' Either search for indices corresponding to values in \code{set}, or
+    #' for indices corresponding to values in range [a,b].
+    #' @param set a vector of values 
+    #' @param a lower bound
+    #' @param b upper bound
+    get_size_of = function(set = NULL, a = NULL, b = NULL) {        
+        if(!is.null(set)) {
+            return(integer_variable_get_size_of_set(self$.variable, set))
+        }
+        if(!is.null(a) & !is.null(b)) {
+            stopifnot(a < b)
+            return(integer_variable_get_size_of_range(self$.variable, a, b))           
+        }
+        stop("please provide a set of values to check, or both bounds of range [a,b]")        
+    },
+
     #' @description Queue an update for a variable. There are 4 types of variable update:
     #'
     #' 1. Subset update. The index vector represents a subset of the variable to

--- a/inst/include/CategoricalVariable.h
+++ b/inst/include/CategoricalVariable.h
@@ -50,6 +50,22 @@ struct CategoricalVariable : public Variable {
         return result;
     }
 
+    virtual int get_size_of(
+        const std::vector<std::string> categories        
+    ) const {
+        int result{0};
+        for (const auto& category : categories) {
+            if (indices.find(category) == indices.end()) {
+                std::stringstream message;
+                message << "unknown category: " << category;
+                Rcpp::stop(message.str());
+            } else {
+                result += indices.at(category).size();
+            }            
+        }
+        return result;
+    }
+
     virtual void queue_update(
         const std::string category,
         const individual_index_t& index

--- a/inst/include/DoubleVariable.h
+++ b/inst/include/DoubleVariable.h
@@ -40,6 +40,40 @@ struct DoubleVariable : public Variable {
         return result;
     }
 
+    // get indices of individuals whose value is in some [a,b]
+    virtual individual_index_t get_index_of_range(
+        const int a, const int b
+    ) const {
+        
+        std::vector<size_t> result_ix;
+        for(size_t it = 0; it < values.size(); it++) {
+            if( !(values[it] < a) && !(b < values[it]) ) {
+                result_ix.push_back(it);
+            }
+        }
+
+        auto result = individual_index_t(size);
+        result.insert_safe(result_ix.begin(), result_ix.end());
+        return result;
+
+    }
+
+    // get indices of individuals whose value is in some [a,b]
+    virtual int get_size_of_range(
+        const int a, const int b
+    ) const {
+        
+        int result;
+        for(size_t it = 0; it < values.size(); it++) {
+            if( !(values[it] < a) && !(b < values[it]) ) {
+                result += 1;
+            }
+        }
+
+        return result;
+
+    }
+
     virtual void queue_update(
         const std::vector<double>& values,
         const std::vector<size_t>& index

--- a/inst/include/DoubleVariable.h
+++ b/inst/include/DoubleVariable.h
@@ -42,7 +42,7 @@ struct DoubleVariable : public Variable {
 
     // get indices of individuals whose value is in some [a,b]
     virtual individual_index_t get_index_of_range(
-        const int a, const int b
+        const double a, const double b
     ) const {
         
         std::vector<size_t> result_ix;
@@ -60,10 +60,10 @@ struct DoubleVariable : public Variable {
 
     // get indices of individuals whose value is in some [a,b]
     virtual int get_size_of_range(
-        const int a, const int b
+        const double a, const double b
     ) const {
         
-        int result;
+        int result{0};
         for(size_t it = 0; it < values.size(); it++) {
             if( !(values[it] < a) && !(b < values[it]) ) {
                 result += 1;

--- a/inst/include/IntegerVariable.h
+++ b/inst/include/IntegerVariable.h
@@ -41,7 +41,7 @@ struct IntegerVariable : public Variable {
         return result;
     }
 
-    // get indices of individual's whose value is in some set
+    // get indices of individuals whose value is in some set
     virtual individual_index_t get_index_of_set(
         const std::vector<int> values_set
     ) const {
@@ -59,7 +59,7 @@ struct IntegerVariable : public Variable {
  
     } 
 
-    // get indices of individual's whose value is in some [a,b]
+    // get indices of individuals whose value is in some [a,b]
     virtual individual_index_t get_index_of_range(
         const int a, const int b
     ) const {
@@ -75,7 +75,39 @@ struct IntegerVariable : public Variable {
         result.insert_safe(result_ix.begin(), result_ix.end());
         return result;
 
-    } 
+    }
+
+    // get number of individuals whose value is in some set
+    virtual int get_size_of_set(
+        const std::vector<int> values_set
+    ) const {
+        int result{0};
+        for(size_t it = 0; it < values.size(); it++){
+            auto findit = std::find(values_set.begin(), values_set.end(), values[it]);
+            if(findit != values_set.end()){
+                result += 1;
+            }
+        }
+
+        return result;
+ 
+    }
+
+    // get number of individuals whose value is in some [a,b]
+    virtual int get_size_of_range(
+        const int a, const int b
+    ) const {
+        
+        int result{0};
+        for(size_t it = 0; it < values.size(); it++) {
+            if( !(values[it] < a) && !(b < values[it]) ) {
+                result += 1;
+            }
+        }
+
+        return result;
+
+    }
 
     // queue variable update
     virtual void queue_update(

--- a/man/CategoricalVariable.Rd
+++ b/man/CategoricalVariable.Rd
@@ -12,6 +12,7 @@ Used to quickly find individuals who could be in one of many options
 \itemize{
 \item \href{#method-new}{\code{CategoricalVariable$new()}}
 \item \href{#method-get_index_of}{\code{CategoricalVariable$get_index_of()}}
+\item \href{#method-get_size_of}{\code{CategoricalVariable$get_size_of()}}
 \item \href{#method-queue_update}{\code{CategoricalVariable$queue_update()}}
 \item \href{#method-.update}{\code{CategoricalVariable$.update()}}
 \item \href{#method-clone}{\code{CategoricalVariable$clone()}}
@@ -44,6 +45,23 @@ individual}
 return a bitset for individuals with the given `values`
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{CategoricalVariable$get_index_of(values)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{values}}{the values to filter}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-get_size_of"></a>}}
+\if{latex}{\out{\hypertarget{method-get_size_of}{}}}
+\subsection{Method \code{get_size_of()}}{
+return the number of individuals with the given `values`
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{CategoricalVariable$get_size_of(values)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{

--- a/man/DoubleVariable.Rd
+++ b/man/DoubleVariable.Rd
@@ -11,6 +11,8 @@ Represents a double variable for an individual in our simulation
 \itemize{
 \item \href{#method-new}{\code{DoubleVariable$new()}}
 \item \href{#method-get_values}{\code{DoubleVariable$get_values()}}
+\item \href{#method-get_index_of}{\code{DoubleVariable$get_index_of()}}
+\item \href{#method-get_size_of}{\code{DoubleVariable$get_size_of()}}
 \item \href{#method-queue_update}{\code{DoubleVariable$queue_update()}}
 \item \href{#method-.update}{\code{DoubleVariable$.update()}}
 \item \href{#method-clone}{\code{DoubleVariable$clone()}}
@@ -47,6 +49,46 @@ get the variable values
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{index}}{optionally return a subset of the variable vector}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-get_index_of"></a>}}
+\if{latex}{\out{\hypertarget{method-get_index_of}{}}}
+\subsection{Method \code{get_index_of()}}{
+return a bitset for individuals whose value lies in an interval
+Search for indices corresponding to values in the interval [a,b].
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{DoubleVariable$get_index_of(a, b)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{a}}{lower bound}
+
+\item{\code{b}}{upper bound}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-get_size_of"></a>}}
+\if{latex}{\out{\hypertarget{method-get_size_of}{}}}
+\subsection{Method \code{get_size_of()}}{
+return the number of individuals whose value lies in an interval
+Count individuals whose value lies in the interval [a,b].
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{DoubleVariable$get_size_of(a, b)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{a}}{lower bound}
+
+\item{\code{b}}{upper bound}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/IntegerVariable.Rd
+++ b/man/IntegerVariable.Rd
@@ -16,6 +16,7 @@ household or age bin.
 \item \href{#method-new}{\code{IntegerVariable$new()}}
 \item \href{#method-get_values}{\code{IntegerVariable$get_values()}}
 \item \href{#method-get_index_of}{\code{IntegerVariable$get_index_of()}}
+\item \href{#method-get_size_of}{\code{IntegerVariable$get_size_of()}}
 \item \href{#method-queue_update}{\code{IntegerVariable$queue_update()}}
 \item \href{#method-.update}{\code{IntegerVariable$.update()}}
 \item \href{#method-clone}{\code{IntegerVariable$clone()}}
@@ -65,6 +66,29 @@ Either search for indices corresponding to values in \code{set}, or
 for indices corresponding to values in range [a,b].
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{IntegerVariable$get_index_of(set = NULL, a = NULL, b = NULL)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{set}}{a vector of values}
+
+\item{\code{a}}{lower bound}
+
+\item{\code{b}}{upper bound}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-get_size_of"></a>}}
+\if{latex}{\out{\hypertarget{method-get_size_of}{}}}
+\subsection{Method \code{get_size_of()}}{
+return the number of individuals with some subset of values
+Either search for indices corresponding to values in \code{set}, or
+for indices corresponding to values in range [a,b].
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{IntegerVariable$get_size_of(set = NULL, a = NULL, b = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -166,6 +166,18 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// categorical_variable_get_size_of
+int categorical_variable_get_size_of(Rcpp::XPtr<CategoricalVariable> variable, const std::vector<std::string>& values);
+RcppExport SEXP _individual_categorical_variable_get_size_of(SEXP variableSEXP, SEXP valuesSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<CategoricalVariable> >::type variable(variableSEXP);
+    Rcpp::traits::input_parameter< const std::vector<std::string>& >::type values(valuesSEXP);
+    rcpp_result_gen = Rcpp::wrap(categorical_variable_get_size_of(variable, values));
+    return rcpp_result_gen;
+END_RCPP
+}
 // categorical_variable_queue_update_vector
 void categorical_variable_queue_update_vector(Rcpp::XPtr<CategoricalVariable> variable, const std::string& value, std::vector<size_t>& index);
 RcppExport SEXP _individual_categorical_variable_queue_update_vector(SEXP variableSEXP, SEXP valueSEXP, SEXP indexSEXP) {
@@ -263,6 +275,32 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::XPtr<DoubleVariable> >::type variable(variableSEXP);
     Rcpp::traits::input_parameter< std::vector<size_t> >::type index(indexSEXP);
     rcpp_result_gen = Rcpp::wrap(double_variable_get_values_at_index_vector(variable, index));
+    return rcpp_result_gen;
+END_RCPP
+}
+// double_variable_get_index_of_range
+Rcpp::XPtr<individual_index_t> double_variable_get_index_of_range(Rcpp::XPtr<DoubleVariable> variable, const int a, const int b);
+RcppExport SEXP _individual_double_variable_get_index_of_range(SEXP variableSEXP, SEXP aSEXP, SEXP bSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<DoubleVariable> >::type variable(variableSEXP);
+    Rcpp::traits::input_parameter< const int >::type a(aSEXP);
+    Rcpp::traits::input_parameter< const int >::type b(bSEXP);
+    rcpp_result_gen = Rcpp::wrap(double_variable_get_index_of_range(variable, a, b));
+    return rcpp_result_gen;
+END_RCPP
+}
+// double_variable_get_size_of_range
+int double_variable_get_size_of_range(Rcpp::XPtr<DoubleVariable> variable, const int a, const int b);
+RcppExport SEXP _individual_double_variable_get_size_of_range(SEXP variableSEXP, SEXP aSEXP, SEXP bSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<DoubleVariable> >::type variable(variableSEXP);
+    Rcpp::traits::input_parameter< const int >::type a(aSEXP);
+    Rcpp::traits::input_parameter< const int >::type b(bSEXP);
+    rcpp_result_gen = Rcpp::wrap(double_variable_get_size_of_range(variable, a, b));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -524,6 +562,31 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// integer_variable_get_size_of_set
+int integer_variable_get_size_of_set(Rcpp::XPtr<IntegerVariable> variable, std::vector<int> values_set);
+RcppExport SEXP _individual_integer_variable_get_size_of_set(SEXP variableSEXP, SEXP values_setSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<IntegerVariable> >::type variable(variableSEXP);
+    Rcpp::traits::input_parameter< std::vector<int> >::type values_set(values_setSEXP);
+    rcpp_result_gen = Rcpp::wrap(integer_variable_get_size_of_set(variable, values_set));
+    return rcpp_result_gen;
+END_RCPP
+}
+// integer_variable_get_size_of_range
+int integer_variable_get_size_of_range(Rcpp::XPtr<IntegerVariable> variable, const int a, const int b);
+RcppExport SEXP _individual_integer_variable_get_size_of_range(SEXP variableSEXP, SEXP aSEXP, SEXP bSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<IntegerVariable> >::type variable(variableSEXP);
+    Rcpp::traits::input_parameter< const int >::type a(aSEXP);
+    Rcpp::traits::input_parameter< const int >::type b(bSEXP);
+    rcpp_result_gen = Rcpp::wrap(integer_variable_get_size_of_range(variable, a, b));
+    return rcpp_result_gen;
+END_RCPP
+}
 // integer_variable_queue_fill
 void integer_variable_queue_fill(Rcpp::XPtr<IntegerVariable> variable, const std::vector<int> value);
 RcppExport SEXP _individual_integer_variable_queue_fill(SEXP variableSEXP, SEXP valueSEXP) {
@@ -602,6 +665,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_individual_create_categorical_variable", (DL_FUNC) &_individual_create_categorical_variable, 2},
     {"_individual_categorical_variable_queue_update", (DL_FUNC) &_individual_categorical_variable_queue_update, 3},
     {"_individual_categorical_variable_get_index_of", (DL_FUNC) &_individual_categorical_variable_get_index_of, 2},
+    {"_individual_categorical_variable_get_size_of", (DL_FUNC) &_individual_categorical_variable_get_size_of, 2},
     {"_individual_categorical_variable_queue_update_vector", (DL_FUNC) &_individual_categorical_variable_queue_update_vector, 3},
     {"_individual_categorical_variable_update", (DL_FUNC) &_individual_categorical_variable_update, 1},
     {"_individual_dummy", (DL_FUNC) &_individual_dummy, 0},
@@ -609,6 +673,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_individual_double_variable_get_values", (DL_FUNC) &_individual_double_variable_get_values, 1},
     {"_individual_double_variable_get_values_at_index", (DL_FUNC) &_individual_double_variable_get_values_at_index, 2},
     {"_individual_double_variable_get_values_at_index_vector", (DL_FUNC) &_individual_double_variable_get_values_at_index_vector, 2},
+    {"_individual_double_variable_get_index_of_range", (DL_FUNC) &_individual_double_variable_get_index_of_range, 3},
+    {"_individual_double_variable_get_size_of_range", (DL_FUNC) &_individual_double_variable_get_size_of_range, 3},
     {"_individual_double_variable_queue_fill", (DL_FUNC) &_individual_double_variable_queue_fill, 2},
     {"_individual_double_variable_queue_update", (DL_FUNC) &_individual_double_variable_queue_update, 3},
     {"_individual_double_variable_update", (DL_FUNC) &_individual_double_variable_update, 1},
@@ -632,6 +698,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_individual_integer_variable_get_values_at_index_vector", (DL_FUNC) &_individual_integer_variable_get_values_at_index_vector, 2},
     {"_individual_integer_variable_get_index_of_set", (DL_FUNC) &_individual_integer_variable_get_index_of_set, 2},
     {"_individual_integer_variable_get_index_of_range", (DL_FUNC) &_individual_integer_variable_get_index_of_range, 3},
+    {"_individual_integer_variable_get_size_of_set", (DL_FUNC) &_individual_integer_variable_get_size_of_set, 2},
+    {"_individual_integer_variable_get_size_of_range", (DL_FUNC) &_individual_integer_variable_get_size_of_range, 3},
     {"_individual_integer_variable_queue_fill", (DL_FUNC) &_individual_integer_variable_queue_fill, 2},
     {"_individual_integer_variable_queue_update", (DL_FUNC) &_individual_integer_variable_queue_update, 3},
     {"_individual_integer_variable_update", (DL_FUNC) &_individual_integer_variable_update, 1},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -279,27 +279,27 @@ BEGIN_RCPP
 END_RCPP
 }
 // double_variable_get_index_of_range
-Rcpp::XPtr<individual_index_t> double_variable_get_index_of_range(Rcpp::XPtr<DoubleVariable> variable, const int a, const int b);
+Rcpp::XPtr<individual_index_t> double_variable_get_index_of_range(Rcpp::XPtr<DoubleVariable> variable, const double a, const double b);
 RcppExport SEXP _individual_double_variable_get_index_of_range(SEXP variableSEXP, SEXP aSEXP, SEXP bSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::XPtr<DoubleVariable> >::type variable(variableSEXP);
-    Rcpp::traits::input_parameter< const int >::type a(aSEXP);
-    Rcpp::traits::input_parameter< const int >::type b(bSEXP);
+    Rcpp::traits::input_parameter< const double >::type a(aSEXP);
+    Rcpp::traits::input_parameter< const double >::type b(bSEXP);
     rcpp_result_gen = Rcpp::wrap(double_variable_get_index_of_range(variable, a, b));
     return rcpp_result_gen;
 END_RCPP
 }
 // double_variable_get_size_of_range
-int double_variable_get_size_of_range(Rcpp::XPtr<DoubleVariable> variable, const int a, const int b);
+int double_variable_get_size_of_range(Rcpp::XPtr<DoubleVariable> variable, const double a, const double b);
 RcppExport SEXP _individual_double_variable_get_size_of_range(SEXP variableSEXP, SEXP aSEXP, SEXP bSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::XPtr<DoubleVariable> >::type variable(variableSEXP);
-    Rcpp::traits::input_parameter< const int >::type a(aSEXP);
-    Rcpp::traits::input_parameter< const int >::type b(bSEXP);
+    Rcpp::traits::input_parameter< const double >::type a(aSEXP);
+    Rcpp::traits::input_parameter< const double >::type b(bSEXP);
     rcpp_result_gen = Rcpp::wrap(double_variable_get_size_of_range(variable, a, b));
     return rcpp_result_gen;
 END_RCPP

--- a/src/categorical_variable.cpp
+++ b/src/categorical_variable.cpp
@@ -41,6 +41,14 @@ Rcpp::XPtr<individual_index_t> categorical_variable_get_index_of(
 }
 
 //[[Rcpp::export]]
+int categorical_variable_get_size_of(
+    Rcpp::XPtr<CategoricalVariable> variable,
+    const std::vector<std::string>& values 
+    ) {
+    return variable->get_size_of(values);
+}
+
+//[[Rcpp::export]]
 void categorical_variable_queue_update_vector(
     Rcpp::XPtr<CategoricalVariable> variable,
     const std::string& value,

--- a/src/double_variable.cpp
+++ b/src/double_variable.cpp
@@ -48,8 +48,8 @@ std::vector<double> double_variable_get_values_at_index_vector(
 // [[Rcpp::export]]
 Rcpp::XPtr<individual_index_t> double_variable_get_index_of_range(
     Rcpp::XPtr<DoubleVariable> variable,
-    const int a,
-    const int b
+    const double a,
+    const double b
 ) {
     return Rcpp::XPtr<individual_index_t>(
         new individual_index_t(variable->get_index_of_range(a, b)),
@@ -60,8 +60,8 @@ Rcpp::XPtr<individual_index_t> double_variable_get_index_of_range(
 // [[Rcpp::export]]
 int double_variable_get_size_of_range(
     Rcpp::XPtr<DoubleVariable> variable,
-    const int a,
-    const int b
+    const double a,
+    const double b
 ) {
     return variable->get_size_of_range(a, b);
 }

--- a/src/double_variable.cpp
+++ b/src/double_variable.cpp
@@ -45,6 +45,27 @@ std::vector<double> double_variable_get_values_at_index_vector(
     return variable->get_values(bitmap);
 }
 
+// [[Rcpp::export]]
+Rcpp::XPtr<individual_index_t> double_variable_get_index_of_range(
+    Rcpp::XPtr<DoubleVariable> variable,
+    const int a,
+    const int b
+) {
+    return Rcpp::XPtr<individual_index_t>(
+        new individual_index_t(variable->get_index_of_range(a, b)),
+        true
+    );
+}
+
+// [[Rcpp::export]]
+int double_variable_get_size_of_range(
+    Rcpp::XPtr<DoubleVariable> variable,
+    const int a,
+    const int b
+) {
+    return variable->get_size_of_range(a, b);
+}
+
 //[[Rcpp::export]]
 void double_variable_queue_fill(
     Rcpp::XPtr<DoubleVariable> variable,

--- a/src/integer_variable.cpp
+++ b/src/integer_variable.cpp
@@ -68,6 +68,24 @@ Rcpp::XPtr<individual_index_t> integer_variable_get_index_of_range(
     );
 }
 
+// [[Rcpp::export]]
+int integer_variable_get_size_of_set(
+    Rcpp::XPtr<IntegerVariable> variable,
+    std::vector<int> values_set
+) {
+    return variable->get_size_of_set(values_set);
+}
+
+// [[Rcpp::export]]
+int integer_variable_get_size_of_range(
+    Rcpp::XPtr<IntegerVariable> variable,
+    const int a,
+    const int b
+) {
+    return variable->get_size_of_range(a, b);
+}
+
+
 //[[Rcpp::export]]
 void integer_variable_queue_fill(
     Rcpp::XPtr<IntegerVariable> variable,

--- a/tests/testthat/test-variables.R
+++ b/tests/testthat/test-variables.R
@@ -28,6 +28,18 @@ test_that("getting a non registered state index fails", {
   )
 })
 
+test_that("getting the size of CategoricalVariable category works", {
+  population <- 10
+  state <- CategoricalVariable$new(c('S', 'I', 'R'), rep('S', population))
+  expect_equal(state$get_size_of('S'), 10)
+})
+
+test_that("getting the size of CategoricalVariable category which does not exist errors gracefully", {
+  population <- 10
+  state <- CategoricalVariable$new(c('S', 'I', 'R'), rep('S', population))
+  expect_error(state$get_size_of('X'))
+})
+
 test_that("getting variables works", {
   size <- 10
   sequence <- DoubleVariable$new(seq_len(size))
@@ -47,7 +59,31 @@ test_that("getting variables at an index works", {
   expect_equal(sequence_2$get_values(5:10), 15:20)
 })
 
-test_that("getting a set of indices which exist works", {
+test_that("getting indices of DoubleVariable in a range works", {
+  dat <- seq(from=0,to=1,by=0.01)
+  var <- DoubleVariable$new(dat)
+
+  empty <- var$get_index_of(a = 500,b = 600)
+  full <- var$get_index_of(a = 0.65,b = 0.89)
+  match_full <- which(dat>=0.65 & dat<=0.89)
+
+  expect_length(empty$to_vector(), 0)
+  expect_equal(full$to_vector(), match_full)
+})
+
+test_that("getting size of DoubleVariable in a range works", {
+  dat <- seq(from=0,to=1,by=0.01)
+  var <- DoubleVariable$new(dat)
+
+  empty <- var$get_size_of(a = 500,b = 600)
+  full <- var$get_size_of(a = 0.65,b = 0.89)
+  match_full <- sum(dat>=0.65 & dat<=0.89)
+
+  expect_equal(empty, 0)
+  expect_equal(full, match_full)
+})
+
+test_that("getting a set of IntegerVariable indices which exist works", {
 
   vals <- 5:10
   intvar <- IntegerVariable$new(vals)
@@ -58,7 +94,7 @@ test_that("getting a set of indices which exist works", {
   expect_equal(indices$to_vector(), 2:4)
 })
 
-test_that("getting a set of indices which do not exist works", {
+test_that("getting a set of IntegerVariable indices which do not exist works", {
 
   vals <- 5:10
   intvar <- IntegerVariable$new(vals)
@@ -69,7 +105,7 @@ test_that("getting a set of indices which do not exist works", {
   expect_length(indices$to_vector(), 0)
 })
 
-test_that("getting indices within bounds which exist works", {
+test_that("getting indices within bounds of IntegerVariable which exist works", {
 
   vals <- 5:10
   intvar <- IntegerVariable$new(vals)
@@ -81,7 +117,7 @@ test_that("getting indices within bounds which exist works", {
   expect_equal(indices$to_vector(), 2:4)
 })
 
-test_that("getting indices within bounds which do not exist works", {
+test_that("getting indices within bounds of IntegerVariable which do not exist works", {
 
   vals <- 5:10
   intvar <- IntegerVariable$new(vals)
@@ -91,4 +127,17 @@ test_that("getting indices within bounds which do not exist works", {
   indices <- intvar$get_index_of(a = a, b = b)  
 
   expect_length(indices$to_vector(), 0)
+})
+
+test_that("getting size of a set of IntegerVariable values which exist works", {
+  intvar <- IntegerVariable$new(-10:10)
+  set <- c(-2,-1,1,2) 
+  expect_equal(intvar$get_size_of(set = set), 4)
+})
+
+test_that("getting size of a interval of IntegerVariable values which exist works", {
+  intvar <- IntegerVariable$new(-10:10)
+  a <- 5
+  b <- 7
+  expect_equal(intvar$get_size_of(a = a, b = b), 3)
 })


### PR DESCRIPTION
This PR adds `get_size_of` methods to IntegerVariable, CategoricalVariable, and DoubleVariable to query the number of individuals in a state without returning a bitset. For IntergerVariable  the user may either ask for the number of values in some set of value or in a interval [a,b]. For DoubleVariable the user asks for the number of values within some interval [a,b]. CategoricalVariable takes a vector of strings as the set to be matched against.

This also adds `get_index_of` to DoubleVariable to return a bitset of individuals whose value is within the interval [a,b].

Please let me know if I am submitting this PR into the wrong upstream branch! I think dev is the right one for it to go but I'm not certain.