### PR TITLE
Add xor for two bitsets

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -41,6 +41,10 @@ bitset_xor <- function(a, b) {
     invisible(.Call(`_individual_bitset_xor`, a, b))
 }
 
+bitset_set_difference <- function(a, b) {
+    invisible(.Call(`_individual_bitset_set_difference`, a, b))
+}
+
 bitset_sample <- function(b, rate) {
     invisible(.Call(`_individual_bitset_sample`, b, rate))
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -37,6 +37,10 @@ bitset_or <- function(a, b) {
     invisible(.Call(`_individual_bitset_or`, a, b))
 }
 
+bitset_xor <- function(a, b) {
+    invisible(.Call(`_individual_bitset_xor`, a, b))
+}
+
 bitset_sample <- function(b, rate) {
     invisible(.Call(`_individual_bitset_sample`, b, rate))
 }

--- a/R/bitset.R
+++ b/R/bitset.R
@@ -58,6 +58,13 @@ Bitset <- R6::R6Class(
     #' @description to "bitwise not" or complement a Bitset
     not = function() Bitset$new(from = bitset_not(self$.bitset)),
 
+    #' @description to "bitwise xor" or the set difference of this Bitset with another
+    #' (keep elements of this Bitset which are not in \code{other}).
+    xor = function(other){
+      bitset_xor(self$.bitset, other$.bitset)
+      self
+    },
+
     #' @description to sample a subset
     #' @param rate the success rate for keeping each element, can be
     #' a single value for all elements or a vector with of unique

--- a/R/bitset.R
+++ b/R/bitset.R
@@ -58,10 +58,17 @@ Bitset <- R6::R6Class(
     #' @description to "bitwise not" or complement a Bitset
     not = function() Bitset$new(from = bitset_not(self$.bitset)),
 
-    #' @description to "bitwise xor" or the set difference of this Bitset with another
-    #' (keep elements of this Bitset which are not in \code{other}).
+    #' @description to "bitwise xor" or get the symmetric difference of two Bitsets
+    #' (keep elements in either Bitset but not in their intersection)
     xor = function(other){
       bitset_xor(self$.bitset, other$.bitset)
+      self
+    },
+
+    #' @description Take the set difference of this Bitset with another
+    #' (keep elements of this Bitset which are not in \code{other}).
+    set_difference = function(other){
+      bitset_set_difference(self$.bitset, other$.bitset)
       self
     },
 

--- a/inst/include/IterableBitset.h
+++ b/inst/include/IterableBitset.h
@@ -73,9 +73,11 @@ public:
     bool operator!=(const IterableBitset&) const;
     IterableBitset operator&(const IterableBitset&) const;
     IterableBitset operator|(const IterableBitset&) const;
+    IterableBitset operator^(const IterableBitset&) const;
     IterableBitset operator~() const;
     IterableBitset& operator&=(const IterableBitset&);
     IterableBitset& operator|=(const IterableBitset&);
+    IterableBitset& operator^=(const IterableBitset&);
     iterator begin();
     const_iterator begin() const;
     const_iterator cbegin() const;
@@ -226,6 +228,11 @@ inline IterableBitset<A> IterableBitset<A>::operator |(const IterableBitset<A>& 
 }
 
 template<class A>
+inline IterableBitset<A> IterableBitset<A>::operator ^(const IterableBitset<A>& other) const {
+    return IterableBitset<A>(*this) ^= other;
+}
+
+template<class A>
 inline IterableBitset<A> IterableBitset<A>::operator ~() const {
     auto result = IterableBitset<A>(*this);
     for (auto i = 0u; i < result.bitmap.size(); ++i) {
@@ -263,6 +270,20 @@ inline IterableBitset<A>& IterableBitset<A>::operator |=(const IterableBitset<A>
     }
     return *this;
 }
+
+template<class A>
+inline IterableBitset<A>& IterableBitset<A>::operator ^=(const IterableBitset<A>& other) {
+    if (max_size() != other.max_size()) {
+        Rcpp::stop("Incompatible bitmap sizes");
+    }
+    n = 0;
+    for (auto i = 0u; i < bitmap.size(); ++i) {
+        bitmap[i] ^= other.bitmap[i];
+        n += popcount(bitmap[i]);
+    }
+    return *this;
+}
+
 
 template<class A>
 inline typename IterableBitset<A>::iterator IterableBitset<A>::begin() {

--- a/man/Bitset.Rd
+++ b/man/Bitset.Rd
@@ -27,6 +27,7 @@ perform an operation without destroying your current bitset.
 \item \href{#method-or}{\code{Bitset$or()}}
 \item \href{#method-and}{\code{Bitset$and()}}
 \item \href{#method-not}{\code{Bitset$not()}}
+\item \href{#method-xor}{\code{Bitset$xor()}}
 \item \href{#method-sample}{\code{Bitset$sample()}}
 \item \href{#method-copy}{\code{Bitset$copy()}}
 \item \href{#method-to_vector}{\code{Bitset$to_vector()}}
@@ -137,6 +138,17 @@ to "bitwise and" or intersect two Bitsets
 to "bitwise not" or complement a Bitset
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Bitset$not()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-xor"></a>}}
+\if{latex}{\out{\hypertarget{method-xor}{}}}
+\subsection{Method \code{xor()}}{
+to "bitwise xor" or the set difference of this Bitset with another
+(keep elements of this Bitset which are not in \code{other}).
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Bitset$xor(other)}\if{html}{\out{</div>}}
 }
 
 }

--- a/man/Bitset.Rd
+++ b/man/Bitset.Rd
@@ -28,6 +28,7 @@ perform an operation without destroying your current bitset.
 \item \href{#method-and}{\code{Bitset$and()}}
 \item \href{#method-not}{\code{Bitset$not()}}
 \item \href{#method-xor}{\code{Bitset$xor()}}
+\item \href{#method-set_difference}{\code{Bitset$set_difference()}}
 \item \href{#method-sample}{\code{Bitset$sample()}}
 \item \href{#method-copy}{\code{Bitset$copy()}}
 \item \href{#method-to_vector}{\code{Bitset$to_vector()}}
@@ -145,10 +146,21 @@ to "bitwise not" or complement a Bitset
 \if{html}{\out{<a id="method-xor"></a>}}
 \if{latex}{\out{\hypertarget{method-xor}{}}}
 \subsection{Method \code{xor()}}{
-to "bitwise xor" or the set difference of this Bitset with another
-(keep elements of this Bitset which are not in \code{other}).
+to "bitwise xor" or get the symmetric difference of two Bitsets
+(keep elements in either Bitset but not in their intersection)
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Bitset$xor(other)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-set_difference"></a>}}
+\if{latex}{\out{\hypertarget{method-set_difference}{}}}
+\subsection{Method \code{set_difference()}}{
+Take the set difference of this Bitset with another
+(keep elements of this Bitset which are not in \code{other}).
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Bitset$set_difference(other)}\if{html}{\out{</div>}}
 }
 
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -119,6 +119,17 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
+// bitset_set_difference
+void bitset_set_difference(const Rcpp::XPtr<individual_index_t> a, const Rcpp::XPtr<individual_index_t> b);
+RcppExport SEXP _individual_bitset_set_difference(SEXP aSEXP, SEXP bSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const Rcpp::XPtr<individual_index_t> >::type a(aSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::XPtr<individual_index_t> >::type b(bSEXP);
+    bitset_set_difference(a, b);
+    return R_NilValue;
+END_RCPP
+}
 // bitset_sample
 void bitset_sample(const Rcpp::XPtr<individual_index_t> b, double rate);
 RcppExport SEXP _individual_bitset_sample(SEXP bSEXP, SEXP rateSEXP) {
@@ -793,6 +804,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_individual_bitset_not", (DL_FUNC) &_individual_bitset_not, 1},
     {"_individual_bitset_or", (DL_FUNC) &_individual_bitset_or, 2},
     {"_individual_bitset_xor", (DL_FUNC) &_individual_bitset_xor, 2},
+    {"_individual_bitset_set_difference", (DL_FUNC) &_individual_bitset_set_difference, 2},
     {"_individual_bitset_sample", (DL_FUNC) &_individual_bitset_sample, 2},
     {"_individual_bitset_sample_vector", (DL_FUNC) &_individual_bitset_sample_vector, 2},
     {"_individual_bitset_to_vector", (DL_FUNC) &_individual_bitset_to_vector, 1},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -108,6 +108,17 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
+// bitset_xor
+void bitset_xor(const Rcpp::XPtr<individual_index_t> a, const Rcpp::XPtr<individual_index_t> b);
+RcppExport SEXP _individual_bitset_xor(SEXP aSEXP, SEXP bSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const Rcpp::XPtr<individual_index_t> >::type a(aSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::XPtr<individual_index_t> >::type b(bSEXP);
+    bitset_xor(a, b);
+    return R_NilValue;
+END_RCPP
+}
 // bitset_sample
 void bitset_sample(const Rcpp::XPtr<individual_index_t> b, double rate);
 RcppExport SEXP _individual_bitset_sample(SEXP bSEXP, SEXP rateSEXP) {
@@ -781,6 +792,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_individual_bitset_and", (DL_FUNC) &_individual_bitset_and, 2},
     {"_individual_bitset_not", (DL_FUNC) &_individual_bitset_not, 1},
     {"_individual_bitset_or", (DL_FUNC) &_individual_bitset_or, 2},
+    {"_individual_bitset_xor", (DL_FUNC) &_individual_bitset_xor, 2},
     {"_individual_bitset_sample", (DL_FUNC) &_individual_bitset_sample, 2},
     {"_individual_bitset_sample_vector", (DL_FUNC) &_individual_bitset_sample_vector, 2},
     {"_individual_bitset_to_vector", (DL_FUNC) &_individual_bitset_to_vector, 1},

--- a/src/bitset.cpp
+++ b/src/bitset.cpp
@@ -80,6 +80,14 @@ void bitset_xor(
     const Rcpp::XPtr<individual_index_t> a,
     const Rcpp::XPtr<individual_index_t> b
     ) {
+    (*a) ^= (*b);
+}
+
+//[[Rcpp::export]]
+void bitset_set_difference(
+    const Rcpp::XPtr<individual_index_t> a,
+    const Rcpp::XPtr<individual_index_t> b
+    ) {
     (*a) &= ~(*b);
 }
 

--- a/src/bitset.cpp
+++ b/src/bitset.cpp
@@ -76,6 +76,14 @@ void bitset_or(
 }
 
 //[[Rcpp::export]]
+void bitset_xor(
+    const Rcpp::XPtr<individual_index_t> a,
+    const Rcpp::XPtr<individual_index_t> b
+    ) {
+    (*a) &= ~(*b);
+}
+
+//[[Rcpp::export]]
 void bitset_sample(
     const Rcpp::XPtr<individual_index_t> b,
     double rate

--- a/tests/testthat/test-bitset.R
+++ b/tests/testthat/test-bitset.R
@@ -42,6 +42,19 @@ test_that("bitset or works", {
   expect_equal(a$to_vector(), c(1, 3, 5, 6, 7))
 })
 
+test_that("bitset xor works", {
+  a <- Bitset$new(100)
+  b <- Bitset$new(100)
+  a0 <- 1:50
+  b0 <- 30:70
+  a$insert(a0)
+  b$insert(b0)
+  a$xor(b)
+  expect_equal(
+    a$to_vector(), setdiff(a0,b0)
+  )
+})
+
 test_that("bitset combinations work", {
   a <- Bitset$new(10)$not()
   b <- Bitset$new(10)


### PR DESCRIPTION
Being able to do XOR on two bitsets is useful when dealing with complicated divisions of state space, this PR adds (and tests) that functionality.