### PR TITLE
Feature/default render

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -22,7 +22,7 @@ Render <- R6::R6Class(
     #' Set a default value for a rendered output
     #' renderers
     #' @param name the variable to set a default for
-    #' @parm value  the defualt value to set for a variable
+    #' @parm value  the default value to set for a variable
     set_default = function(name, value) {
       if (name == 'timestep') {
         stop("Cannot set default value for variable 'timestep'")

--- a/R/render.R
+++ b/R/render.R
@@ -17,6 +17,18 @@ Render <- R6::R6Class(
       private$.timesteps = timesteps
       private$.vectors[['timestep']] <- seq_len(timesteps)
     },
+    
+    #' @description
+    #' Set a default value for a rendered output
+    #' renderers
+    #' @param name the variable to set a default for
+    #' @parm value  the defualt value to set for a variable
+    set_default = function(name, value) {
+      if (name == 'timestep') {
+        stop("Cannot set default value for variable 'timestep'")
+      }
+      private$.vectors[[name]] = rep(value, private$.timesteps)
+    },
 
     #' @description
     #' Update the render with new simulation data

--- a/man/Render.Rd
+++ b/man/Render.Rd
@@ -10,6 +10,7 @@ Class to render output for the simulation
 \subsection{Public methods}{
 \itemize{
 \item \href{#method-new}{\code{Render$new()}}
+\item \href{#method-set_default}{\code{Render$set_default()}}
 \item \href{#method-render}{\code{Render$render()}}
 \item \href{#method-to_dataframe}{\code{Render$to_dataframe()}}
 \item \href{#method-clone}{\code{Render$clone()}}
@@ -29,6 +30,24 @@ renderers
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{timesteps}}{number of timesteps in the simulation}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-set_default"></a>}}
+\if{latex}{\out{\hypertarget{method-set_default}{}}}
+\subsection{Method \code{set_default()}}{
+Set a default value for a rendered output
+renderers
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Render$set_default(name, value)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{name}}{the variable to set a default for}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -39,3 +39,15 @@ test_that("Prefab state counts work correctly", {
   )
   expect_mapequal(rendered, expected)
 })
+
+test_that("Render default works", {
+  render <- Render$new(3)
+  render$set_default('human_S_count', 100)
+  render$render('human_S_count', 10, 2)
+  true_render <- data.frame(
+    timestep = c(1, 2, 3),
+    human_S_count = c(100, 10, 100)
+  )
+  rendered <- render$to_dataframe()
+  expect_mapequal(true_render, rendered)
+})


### PR DESCRIPTION
Adding functionality to `Render` to allow the user to set the default value for a variable.

This is useful if the user will render variables that won't get called every timestep, and will want to set  a default, instead of NA (most likely to 0).

There seems to be a few different ways this feature could be implemented - this one seems fairly tidy.