### PR TITLE
Updates to Performance vignette

### DIFF
--- a/vignettes/Performance.Rmd
+++ b/vignettes/Performance.Rmd
@@ -63,9 +63,33 @@ infection_process <- function(t){
 
 When creating a new Bitset, a user must specify the maximum size of the bitset. This is the maximum number of positive integers which the bitset can store. For example, if calling `Bitset$new(size = 100)`, the resulting object is able to store the presence or absence of integers between 1 and 100 (inclusive). Attempting to insert or remove elements outside of this range will result in an error.
 
-Bitsets offer methods to preform unions (`Bitset$or()`), intersections (`Bitset$and()`), symmetric set difference (also known as exclusive or, `Bitset$xor()`), and set difference (`Bitset$set_difference()`) with other bitsets. These methods modify the bitset in-place. The method `Bitset$not()` gives the complement of a bitset, and returns a new `individual::Bitset` object, leaving the original bitset intact. Because these set operations use bitwise operations directly rather than more expensive relational operators, computations with bitsets are extremely fast. Insertion and removal of elements are also supported.
+Bitsets offer methods to preform unions (`Bitset$or()`), intersections (`Bitset$and()`), symmetric set difference (also known as exclusive or, `Bitset$xor()`), and set difference (`Bitset$set_difference()`) with other bitsets. These methods modify the bitset in-place. The method `Bitset$not()` gives the complement of a bitset, and returns a new `individual::Bitset` object, leaving the original bitset intact. Because these set operations use bitwise operations directly rather than more expensive relational operators, computations with bitsets are extremely fast. Taking advantage of bitset operations can help make processes in "individual" much faster.
 
-Because a bitset stores integers in some finite set, it can be returned as an integer vector by using `Bitset$to_vector()`. However, this is a slow and expensive operation, as data must be copied into a new vector which is returned to R. If your model's dynamics require the frequent returning of integer vectors, an `individual::IntegerVector` object will be more appropriate. However, for most discrete variables with a finite range of values, and especially those which mirror compartments in mathematical models, bitset operations and `individual::CategoricalVariable` (which uses bitsets internally) should be preferred. Taking advantage of bitset operations can help make processes in "individual" much faster.
+This can be seen when implementing a common pattern in epidemiological models: sampling success or failure for a bitset of individuals, and then generating two bitsets to hold individuals sampled one way or the other. A first method might use `individual::filter_bitset`.
+
+```{r,eval=FALSE}
+n <- 1e4
+bset <- Bitset$new(n)$insert(1:n)
+probs <- runif(n)
+
+keep <- probs >= 0.5
+
+stay <- filter_bitset(bitset = bset,other = which(keep))
+leave <- filter_bitset(bitset = bset,other = which(!keep))
+```
+
+This pattern is almost always slower than using the sample method with a set difference:
+
+```{r,eval=FALSE}
+stay <- bset$copy()
+stay$sample(rate = probs)
+
+leave <- bset$copy()$set_difference(stay)
+```
+
+In both instances the original bitset object `bset` is not modified. The latter pattern can be made even faster if the original may be modified by directly taking the set difference with it. For models with large population sizes, the speed differences can be substantial. 
+
+Because a bitset stores integers in some finite set, it can be returned as an integer vector by using `Bitset$to_vector()`. However, this is a slow and expensive operation, as data must be copied into a new vector which is returned to R. If your model's dynamics require the frequent returning of integer vectors, an `individual::IntegerVector` object will be more appropriate. However, for most discrete variables, and especially those which mirror compartments in mathematical models, bitset operations and `individual::CategoricalVariable` (which uses bitsets internally) should be preferred.
 
 ### Prefabs {#prefab}
 
@@ -97,15 +121,16 @@ These are the basic steps to add C++ processes to your R package:
 1. Run `usethis::use_rcpp` to set your package up for C++ development.
 2. Add `individual` to the `LinkingTo` section of your package DESCRIPTION.
 3. If you package is named `mypackage`, create a header file containing `#include<individual.h>` in any of these locations:
-  ```
-  src/mypackage_types.h
-  src/mypackage_types.hpp
-  inst/include/mypackage_types.h
-  inst/include/mypackage_types.hpp
-  ```
-  Then this header file will be automatically included in `RcppExports.cpp`. For more information, see section "2.5 Types in Generated Code" in the [Rcpp Attributes vignette](https://cran.r-project.org/web/packages/Rcpp/vignettes/Rcpp-attributes.pdf).
+    ```{cpp, eval=FALSE}
+    src/mypackage_types.h
+    src/mypackage_types.hpp
+    inst/include/mypackage_types.h
+    inst/include/mypackage_types.hpp
+    ```
+    Then this header file will be automatically included in `RcppExports.cpp`. For more information, see section "2.5 Types in Generated Code" in the [Rcpp Attributes vignette](https://cran.r-project.org/web/packages/Rcpp/vignettes/Rcpp-attributes.pdf).
   
-4. Write your process!
+4. Create a file `src/Makecars` containing the line `CXX_STD = CXX14`. Because `individual` uses C++14 features, when compiling your package against it you must let the compiler know it should use the C++14 standard, otherwise it will not be able to compile. 
+5. Write your process!
 
 Processes in C++ are of type `process_t`, defined in `inst/include/common_types.h`. Types for listeners for `individual::Event` and `individual::TargetedEvent` are `listener_t` and `targeted_listener_t`, defined in `inst/include/Event.h`. Below is how the C++ implementation of
 `multi_probability_bernoulli_process` is coded.


### PR DESCRIPTION
Adds a section to demonstrate the bitset$sample() and bitset$set_difference() pattern being faster than calling filter_bitset() twice. It's a pretty common pattern so worth showing people up front. Also add the step of creating src/Makevars specifying the c++14 standard to the guide on how to make a package that links with "individual"; without that it won't compile. 