### PR TITLE
Fix Event memory leak:

### DIFF
--- a/inst/include/Event.h
+++ b/inst/include/Event.h
@@ -36,6 +36,7 @@ struct EventBase {
     }
 
     virtual bool should_trigger() = 0;
+    virtual ~EventBase() {};
 };
 
 struct Event : public EventBase {
@@ -64,6 +65,8 @@ struct Event : public EventBase {
     virtual void clear_schedule() {
         simple_schedule.clear();
     }
+
+    virtual ~Event() {};
 };
 
 struct TargetedEvent : public EventBase {
@@ -155,6 +158,8 @@ struct TargetedEvent : public EventBase {
         }
         return scheduled;
     }
+
+    virtual ~TargetedEvent() {};
 };
 
 #endif /* INST_INCLUDE_SCHEDULER_H_ */


### PR DESCRIPTION
Make virtual destructors for events. 🤦 C++ inheritance 101

R gets an `XPtr<EventBase>` so the R garbage collector could only delete that. To delete the derived Event or TargetedEvent the destructor needs to be virtual.

You could quickly recreate the leak with: `R -e "devtools::test(filter='event')" -d 'valgrind --leak-check=full'`