### PR TITLE
add checks for scalar vs. vector in integer variable get_index_of method

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -209,8 +209,12 @@ integer_variable_get_values_at_index_vector <- function(variable, index) {
     .Call(`_individual_integer_variable_get_values_at_index_vector`, variable, index)
 }
 
-integer_variable_get_index_of_set <- function(variable, values_set) {
-    .Call(`_individual_integer_variable_get_index_of_set`, variable, values_set)
+integer_variable_get_index_of_set_vector <- function(variable, values_set) {
+    .Call(`_individual_integer_variable_get_index_of_set_vector`, variable, values_set)
+}
+
+integer_variable_get_index_of_set_scalar <- function(variable, values_set) {
+    .Call(`_individual_integer_variable_get_index_of_set_scalar`, variable, values_set)
 }
 
 integer_variable_get_index_of_range <- function(variable, a, b) {

--- a/R/integer_variable.R
+++ b/R/integer_variable.R
@@ -39,9 +39,13 @@ IntegerVariable <- R6::R6Class(
     #' @param set a vector of values 
     #' @param a lower bound
     #' @param b upper bound
-    get_index_of = function(set = NULL, a = NULL, b = NULL) {        
+    get_index_of = function(set = NULL, a = NULL, b = NULL) {
         if(!is.null(set)) {
-            return(Bitset$new(from = integer_variable_get_index_of_set(self$.variable, set)))
+            if (length(set) > 1) {
+              return(Bitset$new(from = integer_variable_get_index_of_set_vector(self$.variable, set)))
+            } else {
+              return(Bitset$new(from = integer_variable_get_index_of_set_scalar(self$.variable, set)))
+            }
         }
         if(!is.null(a) & !is.null(b)) {
             stopifnot(a < b)

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -628,15 +628,27 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// integer_variable_get_index_of_set
-Rcpp::XPtr<individual_index_t> integer_variable_get_index_of_set(Rcpp::XPtr<IntegerVariable> variable, std::vector<int> values_set);
-RcppExport SEXP _individual_integer_variable_get_index_of_set(SEXP variableSEXP, SEXP values_setSEXP) {
+// integer_variable_get_index_of_set_vector
+Rcpp::XPtr<individual_index_t> integer_variable_get_index_of_set_vector(Rcpp::XPtr<IntegerVariable> variable, std::vector<int> values_set);
+RcppExport SEXP _individual_integer_variable_get_index_of_set_vector(SEXP variableSEXP, SEXP values_setSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::XPtr<IntegerVariable> >::type variable(variableSEXP);
     Rcpp::traits::input_parameter< std::vector<int> >::type values_set(values_setSEXP);
-    rcpp_result_gen = Rcpp::wrap(integer_variable_get_index_of_set(variable, values_set));
+    rcpp_result_gen = Rcpp::wrap(integer_variable_get_index_of_set_vector(variable, values_set));
+    return rcpp_result_gen;
+END_RCPP
+}
+// integer_variable_get_index_of_set_scalar
+Rcpp::XPtr<individual_index_t> integer_variable_get_index_of_set_scalar(Rcpp::XPtr<IntegerVariable> variable, const int values_set);
+RcppExport SEXP _individual_integer_variable_get_index_of_set_scalar(SEXP variableSEXP, SEXP values_setSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<IntegerVariable> >::type variable(variableSEXP);
+    Rcpp::traits::input_parameter< const int >::type values_set(values_setSEXP);
+    rcpp_result_gen = Rcpp::wrap(integer_variable_get_index_of_set_scalar(variable, values_set));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -870,7 +882,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_individual_integer_variable_get_values", (DL_FUNC) &_individual_integer_variable_get_values, 1},
     {"_individual_integer_variable_get_values_at_index", (DL_FUNC) &_individual_integer_variable_get_values_at_index, 2},
     {"_individual_integer_variable_get_values_at_index_vector", (DL_FUNC) &_individual_integer_variable_get_values_at_index_vector, 2},
-    {"_individual_integer_variable_get_index_of_set", (DL_FUNC) &_individual_integer_variable_get_index_of_set, 2},
+    {"_individual_integer_variable_get_index_of_set_vector", (DL_FUNC) &_individual_integer_variable_get_index_of_set_vector, 2},
+    {"_individual_integer_variable_get_index_of_set_scalar", (DL_FUNC) &_individual_integer_variable_get_index_of_set_scalar, 2},
     {"_individual_integer_variable_get_index_of_range", (DL_FUNC) &_individual_integer_variable_get_index_of_range, 3},
     {"_individual_integer_variable_get_size_of_set_vector", (DL_FUNC) &_individual_integer_variable_get_size_of_set_vector, 2},
     {"_individual_integer_variable_get_size_of_set_scalar", (DL_FUNC) &_individual_integer_variable_get_size_of_set_scalar, 2},

--- a/src/integer_variable.cpp
+++ b/src/integer_variable.cpp
@@ -46,9 +46,20 @@ std::vector<int> integer_variable_get_values_at_index_vector(
 }
 
 // [[Rcpp::export]]
-Rcpp::XPtr<individual_index_t> integer_variable_get_index_of_set(
+Rcpp::XPtr<individual_index_t> integer_variable_get_index_of_set_vector(
     Rcpp::XPtr<IntegerVariable> variable,
     std::vector<int> values_set
+) {
+    return Rcpp::XPtr<individual_index_t>(
+        new individual_index_t(variable->get_index_of_set(values_set)),
+        true
+    );
+}
+
+// [[Rcpp::export]]
+Rcpp::XPtr<individual_index_t> integer_variable_get_index_of_set_scalar(
+        Rcpp::XPtr<IntegerVariable> variable,
+        const int values_set
 ) {
     return Rcpp::XPtr<individual_index_t>(
         new individual_index_t(variable->get_index_of_set(values_set)),


### PR DESCRIPTION
Somehow when I addressed this issue for the `get_size_of` method for IntegerVariable objects https://github.com/mrc-ide/individual/pull/98#issuecomment-848964943 I forgot to make that switch for the `get_index_of` method. This adds the check to the R6 class method that dispatches the correct C++ method for returning individuals whose value is in a vector of values or is equal to a scalar value.