### PR TITLE
check if filter_bitset will return empty bitset

### DIFF
--- a/R/bitset.R
+++ b/R/bitset.R
@@ -117,8 +117,16 @@ Bitset <- R6::R6Class(
 #' @export
 filter_bitset = function(bitset, other) {
   if ( inherits(other, "Bitset")) {
-    return(Bitset$new(from = filter_bitset_bitset(bitset$.bitset, other$.bitset)))
+    if (other$size() > 0) {
+      return(Bitset$new(from = filter_bitset_bitset(bitset$.bitset, other$.bitset)))  
+    } else {
+      return(Bitset$new(size = bitset$max_size))
+    }
   } else {
-    return(Bitset$new(from = filter_bitset_vector(bitset$.bitset, as.integer(other))))
+    if (length(other) > 0) {
+      return(Bitset$new(from = filter_bitset_vector(bitset$.bitset, as.integer(other))))  
+    } else {
+      return(Bitset$new(size = bitset$max_size))
+    }
   }
 }

--- a/tests/testthat/test-bitset.R
+++ b/tests/testthat/test-bitset.R
@@ -167,6 +167,13 @@ test_that("bitset filtering works for bitsets", {
   expect_equal(filter_bitset(b, f)$to_vector(), c(1, 6))
 })
 
+test_that("bitset filtering works when given empty index", {
+  b <- Bitset$new(10)$insert(c(1, 5, 6))
+  f <- Bitset$new(10)
+  expect_equal(filter_bitset(b, f)$size(), 0)
+  expect_equal(filter_bitset(b, integer(0))$size(), 0)
+})
+
 test_that("bitset throws error when given bad input probabilities in sample", {
   b <- Bitset$new(10)$insert(1:10)
   expect_error(


### PR DESCRIPTION
This is a very small PR to check if `filter_bitset` will get either a vector of length 0 or an empty bitset for argument `other` and straightaway return an empty bitset if so rather than calling the c++ sampling code. It's a bit faster on a bitset of size 1e5.

![image](https://user-images.githubusercontent.com/10673535/124198493-a180a400-da85-11eb-86d1-3f4936094352.png)
