### PR TITLE
get rid of CRAN check NOTEs

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,4 @@ docs
 codecov.yml
 tests/performance
 joss
+.vscode

--- a/R/bitset.R
+++ b/R/bitset.R
@@ -6,8 +6,8 @@
 #' WARNING: all operations (except \code{$not}) are in-place so please use \code{$copy} 
 #' if you would like to perform an operation without destroying your current bitset.
 #' @importFrom R6 R6Class
-#' @export Bitset
-Bitset <- R6::R6Class(
+#' @export
+Bitset <- R6Class(
   'Bitset',
   public = list(
     #' @field .bitset a pointer to the underlying IterableBitset

--- a/R/categorical_variable.R
+++ b/R/categorical_variable.R
@@ -6,7 +6,7 @@
 #' if possible becuase certain operations will be faster.
 #' @importFrom R6 R6Class
 #' @export
-CategoricalVariable <- R6::R6Class(
+CategoricalVariable <- R6Class(
   'CategoricalVariable',
   public = list(
 

--- a/R/double_variable.R
+++ b/R/double_variable.R
@@ -2,7 +2,7 @@
 #' @description Represents a continuous variable for an individual.
 #' @importFrom R6 R6Class
 #' @export
-DoubleVariable <- R6::R6Class(
+DoubleVariable <- R6Class(
   'DoubleVariable',
   public = list(
     .variable = NULL,

--- a/R/event.R
+++ b/R/event.R
@@ -2,7 +2,7 @@
 #' @description Describes a general event in the simulation
 #' @importFrom R6 R6Class
 #' @export
-Event <- R6::R6Class(
+Event <- R6Class(
   'Event',
   public = list(
 

--- a/R/integer_variable.R
+++ b/R/integer_variable.R
@@ -6,7 +6,7 @@
 #' household or age bin.
 #' @importFrom R6 R6Class
 #' @export
-IntegerVariable <- R6::R6Class(
+IntegerVariable <- R6Class(
   'IntegerVariable',
   public = list(
 

--- a/R/render.R
+++ b/R/render.R
@@ -2,7 +2,7 @@
 #' @description Class to render output for the simulation
 #' @importFrom R6 R6Class
 #' @export
-Render <- R6::R6Class(
+Render <- R6Class(
   'Render',
   private = list(
     .vectors = list(),

--- a/R/targeted_event.R
+++ b/R/targeted_event.R
@@ -1,7 +1,7 @@
 #' @title TargetedEvent Class
 #' @description Describes a targeted event in the simulation
 #' This is useful for events which are triggered for a sub-population.
-#' @import R6 R6Class
+#' @importFrom R6 R6Class
 #' @export
 TargetedEvent <- R6Class(
   'TargetedEvent',

--- a/R/targeted_event.R
+++ b/R/targeted_event.R
@@ -1,6 +1,7 @@
 #' @title TargetedEvent Class
 #' @description Describes a targeted event in the simulation
 #' This is useful for events which are triggered for a sub-population.
+#' @import R6 R6Class
 #' @export
 TargetedEvent <- R6Class(
   'TargetedEvent',

--- a/R/targeted_event.R
+++ b/R/targeted_event.R
@@ -2,7 +2,7 @@
 #' @description Describes a targeted event in the simulation
 #' This is useful for events which are triggered for a sub-population.
 #' @export
-TargetedEvent <- R6::R6Class(
+TargetedEvent <- R6Class(
   'TargetedEvent',
   inherit = Event,
   public = list(

--- a/inst/include/Variable.h
+++ b/inst/include/Variable.h
@@ -9,6 +9,7 @@
 
 struct Variable {
     virtual void update() = 0;
+    virtual ~Variable() {};
 };
 
 #endif /* INST_INCLUDE_VARIABLE_H_ */

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -115,7 +115,7 @@ void process_listener(
 ) {
     size_t t = event->t;
     (*listener)(t);
-};
+}
 
 // [[Rcpp::export]]
 void process_targeted_listener(

--- a/src/prefab.cpp
+++ b/src/prefab.cpp
@@ -56,7 +56,7 @@ Rcpp::XPtr<process_t> fixed_probability_multinomial_process_internal(
         }),
         true
     ); 
-};
+}
 
 
 // [[Rcpp::export]]
@@ -105,7 +105,7 @@ Rcpp::XPtr<process_t> multi_probability_multinomial_process_internal(
         }),
         true
     ); 
-};
+}
 
 // [[Rcpp::export]]
 Rcpp::XPtr<process_t> multi_probability_bernoulli_process_internal(
@@ -129,7 +129,7 @@ Rcpp::XPtr<process_t> multi_probability_bernoulli_process_internal(
         }),
         true
     ); 
-};
+}
 
 // [[Rcpp::export]]
 Rcpp::XPtr<process_t> infection_age_process_internal(


### PR DESCRIPTION
This PR addresses:
1. [compiler warnings in LTO check](https://www.stats.ox.ac.uk/pub/bdr/LTO/individual.out) by adding virtual dtor to base class `Variable`
2. [NOTE regarding namespace in imports field](https://www.r-project.org/nosvn/R.check/r-release-macos-arm64/individual-00check.html) by removing `R6::` qualifier from calls to `R6Class`; may be related to this [issue](https://stat.ethz.ch/pipermail/r-package-devel/2017q4/002066.html).
3. add `.vscode` to the .Rbuildignore file

Tests were ran on rhub with the following platforms `c("macos-highsierra-release-cran","windows-x86_64-release","solaris-x86-patched","debian-gcc-release","ubuntu-gcc-release")` and passed with 0 relevant NOTEs.