### PR TITLE
check for bitset sizes when getting values for integer/double variables

### DIFF
--- a/inst/include/DoubleVariable.h
+++ b/inst/include/DoubleVariable.h
@@ -31,6 +31,9 @@ struct DoubleVariable : public Variable {
     }
 
     virtual std::vector<double> get_values(const individual_index_t& index) {
+        if (size != index.max_size()) {
+            Rcpp::stop("incompatible size bitset used to get values from DoubleVariable");
+        }
         auto result = std::vector<double>(index.size());
         auto result_i = 0u;
         for (auto i : index) {

--- a/inst/include/IntegerVariable.h
+++ b/inst/include/IntegerVariable.h
@@ -32,6 +32,9 @@ struct IntegerVariable : public Variable {
     
     // get value of individuals
     virtual std::vector<int> get_values(const individual_index_t& index) {
+        if (size != index.max_size()) {
+            Rcpp::stop("incompatible size bitset used to get values from IntegerVariable");
+        }
         auto result = std::vector<int>(index.size());
         auto result_i = 0u;
         for (auto i : index) {

--- a/tests/testthat/test-variables.R
+++ b/tests/testthat/test-variables.R
@@ -191,3 +191,16 @@ test_that("getting size of a interval of IntegerVariable values which do not exi
   b <- -40
   expect_equal(intvar$get_size_of(a = a, b = b), 0)
 })
+
+test_that("getting values from IntegerVariable with bitset of incompatible size fails", {
+  x <- IntegerVariable$new(initial_values = 1:100)
+  b <- Bitset$new(1000)$insert(90:110)
+  expect_error(x$get_values(b))
+})
+
+test_that("getting values from DoubleVariable with bitset of incompatible size fails", {
+  x <- DoubleVariable$new(initial_values = 1:100)
+  b <- Bitset$new(1000)$insert(90:110)
+  expect_error(x$get_values(b))
+})
+


### PR DESCRIPTION
This PR should fix #119, and adds a test to check for this in the future. The checks are at the c++ level because the length of the stored vectors is not available at the R level; I think that makes sense and this is a fine place to do the check, this is simply a weird edge case.