### PR TITLE
bitset choose now allows k = n

### DIFF
--- a/R/bitset.R
+++ b/R/bitset.R
@@ -91,18 +91,20 @@ Bitset <- R6Class(
       } else {
         stopifnot(all(is.finite(rate)))
         bitset_sample_vector(self$.bitset, rate)
-      }      
+      }
       self
     },
     
     #' @description choose k random items in the bitset
     #' @param k the number of items in the bitset to keep. The selection of
     #' these k items from N total items in the bitset is random, and
-    #' k should be chosen such that 0 <= k < N.
+    #' k should be chosen such that 0 <= k <= N.
     choose = function(k) {
       stopifnot(is.finite(k))
-      stopifnot(k < bitset_size(self$.bitset))
-      bitset_choose(self$.bitset, as.integer(k))
+      stopifnot(k <= bitset_size(self$.bitset))
+      if (k < self$max_size) {
+        bitset_choose(self$.bitset, as.integer(k))
+      }
       self
     },
 

--- a/man/Bitset.Rd
+++ b/man/Bitset.Rd
@@ -217,7 +217,7 @@ choose k random items in the bitset
 \describe{
 \item{\code{k}}{the number of items in the bitset to keep. The selection of
 these k items from N total items in the bitset is random, and
-k should be chosen such that 0 <= k < N.}
+k should be chosen such that 0 <= k <= N.}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-bitset.R
+++ b/tests/testthat/test-bitset.R
@@ -209,5 +209,5 @@ test_that("bitset choose behaves properly when given a bitset with elements", {
   expect_equal(b$choose(0)$size(), 0)
   
   b <- Bitset$new(10)$insert(1:8)
-  expect_error(b$choose(8))
+  expect_error(b$choose(10))
 })


### PR DESCRIPTION
if `Bitset$choose` is given `k` equal to size of the bitset, do nothing; this used to throw an error which means users have to check for size of `k` versus the bitset prior to using it, which disrupts the way it is used in modelling.