### PR TITLE
IntegerVariable get methods now allow a=b which defaults to set behavior

### DIFF
--- a/R/integer_variable.R
+++ b/R/integer_variable.R
@@ -37,7 +37,7 @@ IntegerVariable <- R6Class(
     #' Either search for indices corresponding to values in \code{set}, or
     #' for indices corresponding to values in range \eqn{[a,b]}. Either \code{set}
     #' or \code{a} and \code{b} must be provided as arguments.
-    #' @param set a vector of values 
+    #' @param set a vector of values (providing \code{set} means \code{a,b} are ignored)
     #' @param a lower bound
     #' @param b upper bound
     get_index_of = function(set = NULL, a = NULL, b = NULL) {
@@ -47,10 +47,14 @@ IntegerVariable <- R6Class(
             } else {
               return(Bitset$new(from = integer_variable_get_index_of_set_scalar(self$.variable, set)))
             }
-        }
-        if(!is.null(a) & !is.null(b)) {
-            stopifnot(a < b)
-            return(Bitset$new(from = integer_variable_get_index_of_range(self$.variable, a, b)))            
+        } else {
+          stopifnot(all(is.finite(c(a,b))))
+          stopifnot(a <= b)
+          if (a < b) {
+            return(Bitset$new(from = integer_variable_get_index_of_range(self$.variable, a, b)))              
+          } else {
+            return(Bitset$new(from = integer_variable_get_index_of_set_scalar(self$.variable, a))) 
+          }
         }
         stop("please provide a set of values to check, or both bounds of range [a,b]")        
     },
@@ -59,22 +63,26 @@ IntegerVariable <- R6Class(
     #' Either search for indices corresponding to values in \code{set}, or
     #' for indices corresponding to values in range \eqn{[a,b]}. Either \code{set}
     #' or \code{a} and \code{b} must be provided as arguments.
-    #' @param set a vector of values 
+    #' @param set a vector of values (providing \code{set} means \code{a,b} are ignored)
     #' @param a lower bound
     #' @param b upper bound
-    get_size_of = function(set = NULL, a = NULL, b = NULL) {        
-        if (!is.null(set)) {
-            if (length(set) > 1) {
-              return(integer_variable_get_size_of_set_vector(self$.variable, set))  
-            } else {
-              return(integer_variable_get_size_of_set_scalar(self$.variable, set))
-            }
+    get_size_of = function(set = NULL, a = NULL, b = NULL) {    
+      if(!is.null(set)) {
+        if (length(set) > 1) {
+          return(integer_variable_get_size_of_set_vector(self$.variable, set))
+        } else {
+          return(integer_variable_get_size_of_set_scalar(self$.variable, set))
         }
-        if (!is.null(a) & !is.null(b)) {
-            stopifnot(a < b)
-            return(integer_variable_get_size_of_range(self$.variable, a, b))           
+      } else {
+        stopifnot(all(is.finite(c(a,b))))
+        stopifnot(a <= b)
+        if (a < b) {
+          return(integer_variable_get_size_of_range(self$.variable, a, b))
+        } else {
+          return(integer_variable_get_size_of_set_scalar(self$.variable, a))
         }
-        stop("please provide a set of values to check, or both bounds of range [a,b]")        
+      }
+      stop("please provide a set of values to check, or both bounds of range [a,b]")    
     },
 
     #' @description Queue an update for a variable. There are 4 types of variable update:

--- a/tests/testthat/test-variables.R
+++ b/tests/testthat/test-variables.R
@@ -192,6 +192,17 @@ test_that("getting size of a interval of IntegerVariable values which do not exi
   expect_equal(intvar$get_size_of(a = a, b = b), 0)
 })
 
+test_that("using a, b in IntegerVariable size and index methods works", {
+  intvar <- IntegerVariable$new(rep(1:10,each=3))
+  a <- 5
+  b <- 5
+  expect_equal(intvar$get_size_of(a = a, b = b), 3)
+  expect_error(intvar$get_size_of(a = 7,b = 4))
+  
+  expect_equal(intvar$get_index_of(a = a, b = b)$to_vector(), c(13, 14, 15))
+  expect_error(intvar$get_index_of(a = 7,b = 4))
+})
+
 test_that("getting values from IntegerVariable with bitset of incompatible size fails", {
   x <- IntegerVariable$new(initial_values = 1:100)
   b <- Bitset$new(1000)$insert(90:110)


### PR DESCRIPTION
Sometimes it is useful to call `IntegerVariable$get_size_of(a = val1, b = val2)` in a modeling context where it is possible for `val1 = val2`; right now this is considered an error and the code requires `a < b`. I propose that in this case (`a = b`) the method should revert to the set behavior with a set consisting of a single element `integer_variable_get_index_of_set_scalar`. This PR implements that for both `get_size_of` and `get_index_of` methods and adds another test.