### PR TITLE
bitset$choose should never be passed negative number

### DIFF
--- a/R/bitset.R
+++ b/R/bitset.R
@@ -102,6 +102,7 @@ Bitset <- R6Class(
     choose = function(k) {
       stopifnot(is.finite(k))
       stopifnot(k <= bitset_size(self$.bitset))
+      stopifnot(k >= 0)
       if (k < self$max_size) {
         bitset_choose(self$.bitset, as.integer(k))
       }


### PR DESCRIPTION
@giovannic I think I found the what's giving the UBSCAN error on CRAN's tests. Using the docker image from [Rich's blog post](https://reside-ic.github.io/blog/debugging-and-fixing-crans-additional-checks-errors/) I found the error occurring at test-bitset.R:186:3, when calling `b$choose(-1)`. See log below:

```
Start test: bitset choose behaves properly when given an empty bitset
  test-bitset.R:186:3 [success]
/usr/local/RDcsan/lib/R/site-library/Rcpp/include/Rcpp/internal/caster.h:30:25: runtime error: -1 is outside the range of representable values of type 'unsigned long'
```

I guess that -1 gets cast to a `size_t` below which causes the issue. This fix should prevent that (it doesn't raise any UBSCAN warnings after I implemented it locally).

https://github.com/mrc-ide/individual/blob/be0966a5440fa66aef61c42ec3520abcc1b50314/src/bitset.cpp#L159-L165