### PR TITLE
Hotfix/cran checks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: individual
 Title: Framework for Specifying and Simulating Individual Based Models
-Version: 0.1.3
+Version: 0.1.4
 Authors@R: c(
   person(
     given = "Giovanni",

--- a/inst/include/IterableBitset.h
+++ b/inst/include/IterableBitset.h
@@ -449,7 +449,7 @@ inline void bitset_choose_internal(
     false // one based
   );
   std::sort(to_remove.begin(), to_remove.end());
-  auto bitset_i = 0u;
+  auto bitset_i = 0;
   auto bitset_it = b.cbegin();
   for (auto i : to_remove) {
     while(bitset_i != i) {


### PR DESCRIPTION
fixed one last unsigned/signed comparison that was giving LTO error in IterableBitset.h `bitset_choose_internal`. No further errors/warnings/notes after running [rhub checks](https://r-hub.github.io/rhub/reference/check_shortcuts.html) `check_with_sanitizers` and `check_with_valgrind`  both with option `--enable-lto=check` enabled (as per the [R manual on writing extensions](https://cran.r-project.org/doc/manuals/r-devel/R-admin.html#LTO-for-package-checking))