### PR TITLE
add statement of need to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ library('remotes')
 install_github('mrc-ide/individual')
 ```
 
+Alternatively you can install individual directly from CRAN, but be aware that
+the CRAN version may not be the most recent version of the package:
+
+```R
+install.packages("individual")
+```
+
 For development it is most convenient to run the code from source. You can
 install the dependencies in RStudio by opening the project and selecting "Build" > "Install and Restart"
 
@@ -53,6 +60,30 @@ how to simulate a simple SIR model in "individual", and later `vignette("API")`
 which describes in detail how to use the data structures in "individual" to
 build more complicated models. If you are running into performance issues,
 learn more about how to speed up your model in `vignette("Performance")`.
+
+## Statement of need
+
+Individual based models are important tools for infectious disease epidemiology,
+but practical use requires an implementation that is both comprehensible so that
+code may be maintained and adapted, and fast. "individual" is an R package which
+provides users a set of primitive classes using the [R6](https://github.com/r-lib/R6)
+class system that define elements common to many tasks in infectious disease
+modeling. Using R6 classes helps ensure that methods invoked on objects are
+appropriate for that object type, aiding in testing and maintenance of models
+programmed using "individual". Computation is carried out in C++ using 
+[Rcpp](https://github.com/RcppCore/Rcpp) to link to R, helping achieve good
+performance for even complex models.
+
+"individual" provides a unique method to specify individual based models compared
+to other agent/individual based modeling libraries, where users specify a type
+for agents, which are subsequently stored in an array or other data structure.
+In "individual", users instead instantiate a object for each variable which
+describes some aspect of state, using the appropriate R6 class. Finding subsets
+of individuals with particular combinations of state variables for further
+computation can be efficiently accomplished with set operations, using a custom
+bitset class implemented in C++. Additionally, the software makes no assumptions
+on the types of models that may be simulated (*e.g.* mass action, network),
+and updates are performed on a discrete time step.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ bitset class implemented in C++. Additionally, the software makes no assumptions
 on the types of models that may be simulated (*e.g.* mass action, network),
 and updates are performed on a discrete time step.
 
+We hope our software is useful to infectious disease modellers, ecologists, and
+others who are interested in individual-based modeling in R.
+
 ## Contributing
 
 Thank you! Please refer to the vignette on `vignette("Contributing")` for info on how to

--- a/vignettes/Contributing.Rmd
+++ b/vignettes/Contributing.Rmd
@@ -30,7 +30,7 @@ For bug reports please include:
 
 ## Git
 
-We use on this project. Which means we use `master`, `dev`, `feat/*`, `bug/*`, `hotfix/*` and `release/*` branches. Please refer to [this post](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) for more information of each type of branch. NOTE: `bug/*` branches are `feat/*` branches which fix a bug.
+We use Git on this project. Which means we use `master`, `dev`, `feat/*`, `bug/*`, `hotfix/*` and `release/*` branches. Please refer to [this post](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) for more information of each type of branch. NOTE: `bug/*` branches are `feat/*` branches which fix a bug.
 
 Practically speaking, *all* new code contributions should be feature branches. You should branch off of the `dev` branch into one called `feat/[your feature name here]`. When we consider pull requests from forked repositories to the mrc-ide/individual repository, we will expect this convention.
 


### PR DESCRIPTION
@giovannic I added a statement of need section to the README as requested in #133 to conform to the [JOSS requirements for documentation here](https://joss.readthedocs.io/en/latest/review_checklist.html#documentation). The text is adapted from the paper to read better to a first time user scrolling over the readme in the repo or on CRAN.
