### PR TITLE
check for bad bitset index when queuing CategoricalVariable updates 

### DIFF
--- a/R/categorical_variable.R
+++ b/R/categorical_variable.R
@@ -48,7 +48,9 @@ CategoricalVariable <- R6Class(
     queue_update = function(value, index) {
       stopifnot(all(value %in% self$get_categories()))
       if (inherits(index, "Bitset")) {
-        categorical_variable_queue_update(self$.variable, value, index$.bitset)        
+        if (index$size() > 0) {
+          categorical_variable_queue_update(self$.variable, value, index$.bitset)
+        }
       } else {
         if (length(index) > 0) {
           stopifnot(all(is.finite(index)))

--- a/src/categorical_variable.cpp
+++ b/src/categorical_variable.cpp
@@ -26,6 +26,9 @@ void categorical_variable_queue_update(
     const std::string& value,
     Rcpp::XPtr<individual_index_t> index
     ) {
+    if (index->max_size() != variable->size) {
+        Rcpp::stop("incompatible size bitset used to queue update for CategoricalVariable");
+    }
     variable->queue_update(value, *index);
 }
 

--- a/tests/testthat/test-categoricalvariable.R
+++ b/tests/testthat/test-categoricalvariable.R
@@ -62,7 +62,7 @@ test_that("getting the size of CategoricalVariable category which does not exist
 test_that("can retrieve categories of CategoricalVariable", {
   values <- c("S","E","I","R")
   var <- CategoricalVariable$new(categories = values,initial_values = rep(values,2))
-  expect_setequal(categorical_variable_get_categories(var$.variable), values)
+  expect_setequal(var$get_categories(), values)
 })
 
 test_that("Queuing invalid category errors", {
@@ -75,5 +75,22 @@ test_that("Queuing invalid category errors", {
 
 test_that("Queuing invalid indices errors", {
   c <- CategoricalVariable$new(categories = c("A","B"),initial_values = rep(c("A","B"),each=10))
-  expect_error(c$queue_update(value = "A",index = c(15,25,50)))
+  expect_error(c$queue_update(value = "A",index = c(15, 25, 50)))
+  expect_error(c$queue_update(value = "A",index = c(-5, 1)))
+  expect_error(c$queue_update(value = "A",index = c(5, NaN)))
+  expect_error(c$queue_update(value = "A",index = c(5, NA)))
+  expect_error(c$queue_update(value = "A",index = Bitset$new(50)$insert(c(15, 25, 50))))
+  expect_error(c$queue_update(value = "A",index = Bitset$new(30)$insert(c(15, 17))))
+})
+
+test_that("Updates work correctly", {
+  c <- CategoricalVariable$new(categories = c("A","B"),initial_values = rep(c("A","B"),each=10))
+  b <- 1:5
+  c$queue_update(value = "B", index = b)
+  c$.update()
+  expect_equal(c$get_index_of("A")$to_vector(), 6:10)
+  b <- Bitset$new(20)$insert(1:5)
+  c$queue_update(value = "A", index = b)
+  c$.update()
+  expect_equal(c$get_index_of("A")$to_vector(), 1:10)
 })


### PR DESCRIPTION
Currently the following code does not cause an error, in contrast to how IntegerVariable and DoubleVariable handle bad bitset input when queuing updates:  
```
c <- CategoricalVariable$new(categories = c("A","B"),initial_values = rep(c("A","B"),each=10))
c$queue_update(value = "A",index = Bitset$new(50)$insert(c(15, 25, 50)))
```

It's nicer to make the error handling consistent, as then the error can be traced more easily back to the process that queued the bad indices, rather than starting from when it tried to apply the update. This PR also adds some tests to catch these cases.