### PR TITLE
consistent C++ API for IntegerVariable

### DIFF
--- a/inst/include/IntegerVariable.h
+++ b/inst/include/IntegerVariable.h
@@ -41,8 +41,8 @@ struct IntegerVariable : public Variable {
     virtual individual_index_t get_index_of_set(const int value) const;
     virtual individual_index_t get_index_of_range(const int a, const int b) const;
     
-    virtual size_t get_size_of_set_vector(const std::vector<int>& values_set) const;
-    virtual size_t get_size_of_set_scalar(const int value) const;
+    virtual size_t get_size_of_set(const std::vector<int>& values_set) const;
+    virtual size_t get_size_of_set(const int value) const;
     virtual size_t get_size_of_range(const int a, const int b) const;
 
     virtual void queue_update(const std::vector<int>& values, const std::vector<size_t>& index);
@@ -136,7 +136,7 @@ inline individual_index_t IntegerVariable::get_index_of_range(
 }
 
 //' @title return number of individuals whose value is in a finite set
-inline size_t IntegerVariable::get_size_of_set_vector(
+inline size_t IntegerVariable::get_size_of_set(
         const std::vector<int>& values_set
 ) const {
     
@@ -149,7 +149,7 @@ inline size_t IntegerVariable::get_size_of_set_vector(
 }
 
 //' @title return number of individuals whose value is equal to a specific scalar
-inline size_t IntegerVariable::get_size_of_set_scalar(
+inline size_t IntegerVariable::get_size_of_set(
         const int value
 ) const {
     

--- a/src/integer_variable.cpp
+++ b/src/integer_variable.cpp
@@ -89,7 +89,7 @@ size_t integer_variable_get_size_of_set_vector(
     Rcpp::XPtr<IntegerVariable> variable,
     const std::vector<int> values_set
 ) {
-    return variable->get_size_of_set_vector(values_set);
+    return variable->get_size_of_set(values_set);
 }
 
 // [[Rcpp::export]]
@@ -97,7 +97,7 @@ size_t integer_variable_get_size_of_set_scalar(
         Rcpp::XPtr<IntegerVariable> variable,
         const int value
 ) {
-    return variable->get_size_of_set_scalar(value);
+    return variable->get_size_of_set(value);
 }
 
 // [[Rcpp::export]]


### PR DESCRIPTION
This very small PR just takes the `IntegerVariable::get_size_of_set_vector` and `IntegerVariable::get_size_of_set_scalar` methods and makes them a single overloaded method, for consistency with how the other methods that may take either a vector or a scalar are implemented.