### PR TITLE
fix bug with cpp event listeners

### DIFF
--- a/R/event.R
+++ b/R/event.R
@@ -36,7 +36,7 @@ Event <- R6Class(
       for (listener in self$.listeners) {
         if (event_should_trigger(self$.event)) {
           if (inherits(listener, "externalptr")) {
-            self$.process_listener_cpp(self$.event, listener)
+            self$.process_listener_cpp(listener)
           } else {
             self$.process_listener(listener)
           }


### PR DESCRIPTION
Fix a simple bug that prevents event listeners written in C++ from executing properly.