### PR TITLE
Epic/resizable simple

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,7 +57,7 @@ Suggests:
     testthat (>= 2.1.0),
     xml2,
     bench
-RoxygenNote: 7.2.0
+RoxygenNote: 7.1.1
 VignetteBuilder: knitr
 LinkingTo:
   Rcpp,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,7 +57,7 @@ Suggests:
     testthat (>= 2.1.0),
     xml2,
     bench
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.0
 VignetteBuilder: knitr
 LinkingTo:
   Rcpp,

--- a/R/bitset.R
+++ b/R/bitset.R
@@ -1,8 +1,8 @@
 #' @title A Bitset Class
-#' @description This is a data structure that compactly stores the presence of 
-#' integers in some finite set (\code{max_size}), and can 
+#' @description This is a data structure that compactly stores the presence of
+#' integers in some finite set (\code{max_size}), and can
 #' efficiently perform set operations (union, intersection, complement, symmetric
-#' difference, set difference). 
+#' difference, set difference).
 #' WARNING: All operations are in-place so please use \code{$copy}
 #' if you would like to perform an operation without destroying your current bitset.
 #' @importFrom R6 R6Class
@@ -43,13 +43,13 @@ Bitset <- R6Class(
       bitset_remove(self$.bitset, v)
       self
     },
-    
+
     #' @description clear the bitset.
-    clear = function(v) {
+    clear = function() {
       bitset_clear(self$.bitset)
       self
     },
-    
+
     #' @description get the number of elements in the set.
     size = function() bitset_size(self$.bitset),
 
@@ -104,7 +104,7 @@ Bitset <- R6Class(
     #' a single value for all elements or a vector of unique
     #' probabilities for keeping each element.
     sample = function(rate) {
-      stopifnot(is.finite(rate))
+      stopifnot(is.finite(rate), !is.null(rate))
       if (length(rate) == 1) {
         bitset_sample(self$.bitset, rate)
       } else {
@@ -112,7 +112,7 @@ Bitset <- R6Class(
       }
       self
     },
-    
+
     #' @description choose k random items in the bitset
     #' @param k the number of items in the bitset to keep. The selection of
     #' these k items from N total items in the bitset is random, and
@@ -133,7 +133,7 @@ Bitset <- R6Class(
     #' @description return an integer vector of the elements
     #' stored in this bitset.
     to_vector = function() bitset_to_vector(self$.bitset)
-    
+
   )
 )
 
@@ -151,13 +151,13 @@ Bitset <- R6Class(
 filter_bitset = function(bitset, other) {
   if ( inherits(other, "Bitset")) {
     if (other$size() > 0) {
-      return(Bitset$new(from = filter_bitset_bitset(bitset$.bitset, other$.bitset)))  
+      return(Bitset$new(from = filter_bitset_bitset(bitset$.bitset, other$.bitset)))
     } else {
       return(Bitset$new(size = bitset$max_size))
     }
   } else {
     if (length(other) > 0) {
-      return(Bitset$new(from = filter_bitset_vector(bitset$.bitset, as.integer(other))))  
+      return(Bitset$new(from = filter_bitset_vector(bitset$.bitset, as.integer(other))))
     } else {
       return(Bitset$new(size = bitset$max_size))
     }

--- a/R/double_variable.R
+++ b/R/double_variable.R
@@ -34,13 +34,13 @@ DoubleVariable <- R6Class(
       }
     },
 
-    #' @description return a \code{\link[individual]{Bitset}} giving individuals 
+    #' @description return a \code{\link[individual]{Bitset}} giving individuals
     #' whose value lies in an interval \eqn{[a,b]}.
     #' @param a lower bound
     #' @param b upper bound
     get_index_of = function(a, b) {
       stopifnot(a < b)
-      return(Bitset$new(from = double_variable_get_index_of_range(self$.variable, a, b)))      
+      return(Bitset$new(from = double_variable_get_index_of_range(self$.variable, a, b)))
     },
 
     #' @description return the number of individuals whose value lies in an interval
@@ -64,7 +64,7 @@ DoubleVariable <- R6Class(
     #' whose length should match the size of the population, which fills all the variable values in
     #' the population}
     #'  \item{Variable fill: }{The index vector is set to \code{NULL} and the argument \code{values}
-    #' should be a single number, which fills all of the variable values in 
+    #' should be a single number, which fills all of the variable values in
     #' the population.}
     #' }
     #' @param values a vector or scalar of values to assign at the index.
@@ -72,7 +72,7 @@ DoubleVariable <- R6Class(
     #' fill options. If using indices, this may be either a vector of integers or
     #' a \code{\link[individual]{Bitset}}.
     queue_update = function(values, index = NULL) {
-      stopifnot(is.numeric(values))
+      stopifnot(is.numeric(values), !is.null(values))
       if(is.null(index)){
         if(length(values) == 1){
           # variable fill

--- a/R/event.R
+++ b/R/event.R
@@ -16,7 +16,7 @@ Event <- R6Class(
 
     #' @description Add an event listener.
     #' @param listener the function to be executed on the event, which takes a single
-    #' argument giving the time step when this event is triggered. 
+    #' argument giving the time step when this event is triggered.
     add_listener = function(listener) {
       self$.listeners <- c(self$.listeners, listener)
     },
@@ -29,14 +29,14 @@ Event <- R6Class(
 
     #' @description Stop a future event from triggering.
     clear_schedule = function() event_clear_schedule(self$.event),
-  
+
     .tick = function() event_tick(self$.event),
 
     .process = function() {
       for (listener in self$.listeners) {
         if (event_should_trigger(self$.event)) {
           if (inherits(listener, "externalptr")) {
-            self$.process_listener_cpp(self$.event, listener)
+            self$.process_listener_cpp(listener)
           } else {
             self$.process_listener(listener)
           }
@@ -50,7 +50,7 @@ Event <- R6Class(
 
     .process_listener_cpp = function(listener){
       process_listener(
-        event = self$.event, 
+        event = self$.event,
         listener = listener
       )
     },

--- a/R/integer_variable.R
+++ b/R/integer_variable.R
@@ -36,7 +36,7 @@ IntegerVariable <- R6Class(
           return(integer_variable_get_values_at_index_vector(self$.variable, index))
         }
       }
-      
+
     },
 
     #' @description Return a \code{\link[individual]{Bitset}} for individuals with some subset of values.
@@ -58,12 +58,12 @@ IntegerVariable <- R6Class(
           stopifnot(is.finite(c(a,b)))
           stopifnot(a <= b)
           if (a < b) {
-            return(Bitset$new(from = integer_variable_get_index_of_range(self$.variable, a, b)))              
+            return(Bitset$new(from = integer_variable_get_index_of_range(self$.variable, a, b)))
           } else {
-            return(Bitset$new(from = integer_variable_get_index_of_set_scalar(self$.variable, a))) 
+            return(Bitset$new(from = integer_variable_get_index_of_set_scalar(self$.variable, a)))
           }
         }
-        stop("please provide a set of values to check, or both bounds of range [a,b]")        
+        stop("please provide a set of values to check, or both bounds of range [a,b]")
     },
 
     #' @description Return the number of individuals with some subset of values.
@@ -73,9 +73,9 @@ IntegerVariable <- R6Class(
     #' @param set a vector of values (providing \code{set} means \code{a,b} are ignored)
     #' @param a lower bound
     #' @param b upper bound
-    get_size_of = function(set = NULL, a = NULL, b = NULL) {    
+    get_size_of = function(set = NULL, a = NULL, b = NULL) {
       if (!is.null(set)) {
-        stopifnot(is.finite(set))  
+        stopifnot(is.finite(set))
         if (length(set) == 1) {
           return(integer_variable_get_size_of_set_scalar(self$.variable, set))
         } else {
@@ -90,9 +90,9 @@ IntegerVariable <- R6Class(
           return(integer_variable_get_size_of_set_scalar(self$.variable, a))
         }
       }
-      stop("please provide a set of values to check, or both bounds of range [a,b]")    
+      stop("please provide a set of values to check, or both bounds of range [a,b]")
     },
-    
+
     #' @description Queue an update for a variable. There are 4 types of variable update:
     #'
     #' \enumerate{
@@ -106,7 +106,7 @@ IntegerVariable <- R6Class(
     #' whose length should match the size of the population, which fills all the variable values in
     #' the population}
     #'  \item{Variable fill: }{The index vector is set to \code{NULL} and the argument \code{values}
-    #' should be a single number, which fills all of the variable values in 
+    #' should be a single number, which fills all of the variable values in
     #' the population.}
     #' }
     #' @param values a vector or scalar of values to assign at the index
@@ -114,7 +114,7 @@ IntegerVariable <- R6Class(
     #' fill options. If using indices, this may be either a vector of integers or
     #' a \code{\link[individual]{Bitset}}.
     queue_update = function(values, index = NULL) {
-      stopifnot(is.finite(values))
+      stopifnot(is.finite(values), !is.null(values))
       if(is.null(index)){
         if(length(values) == 1){
           # variable fill

--- a/R/targeted_event.R
+++ b/R/targeted_event.R
@@ -14,7 +14,7 @@ TargetedEvent <- R6Class(
     },
 
     #' @description Schedule this event to occur in the future.
-    #' @param target the individuals to pass to the listener, this may be 
+    #' @param target the individuals to pass to the listener, this may be
     #' either a vector of integers or a \code{\link[individual]{Bitset}}.
     #' @param delay the number of time steps to wait before triggering the event,
     #' can be a scalar in which case all targeted individuals are scheduled for
@@ -25,7 +25,7 @@ TargetedEvent <- R6Class(
       if (length(delay) > 1) {
         if (inherits(target, 'Bitset')) {
           if (target$size() > 0){
-            targeted_event_schedule_multi_delay(self$.event, target$.bitset, delay) 
+            targeted_event_schedule_multi_delay(self$.event, target$.bitset, delay)
           }
         } else {
           if (length(target) > 0) {
@@ -108,8 +108,8 @@ TargetedEvent <- R6Class(
     },
 
     .process_listener_cpp = function(listener){
-      individual:::process_targeted_listener(
-        event = self$.event, 
+      process_targeted_listener(
+        event = self$.event,
         listener = listener,
         target = targeted_event_get_target(self$.event)
       )

--- a/man/Bitset.Rd
+++ b/man/Bitset.Rd
@@ -4,10 +4,10 @@
 \alias{Bitset}
 \title{A Bitset Class}
 \description{
-This is a data structure that compactly stores the presence of 
-integers in some finite set (\code{max_size}), and can 
+This is a data structure that compactly stores the presence of
+integers in some finite set (\code{max_size}), and can
 efficiently perform set operations (union, intersection, complement, symmetric
-difference, set difference). 
+difference, set difference).
 WARNING: All operations are in-place so please use \code{$copy}
 if you would like to perform an operation without destroying your current bitset.
 }
@@ -23,26 +23,26 @@ if you would like to perform an operation without destroying your current bitset
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{Bitset$new()}}
-\item \href{#method-insert}{\code{Bitset$insert()}}
-\item \href{#method-remove}{\code{Bitset$remove()}}
-\item \href{#method-clear}{\code{Bitset$clear()}}
-\item \href{#method-size}{\code{Bitset$size()}}
-\item \href{#method-or}{\code{Bitset$or()}}
-\item \href{#method-and}{\code{Bitset$and()}}
-\item \href{#method-not}{\code{Bitset$not()}}
-\item \href{#method-xor}{\code{Bitset$xor()}}
-\item \href{#method-set_difference}{\code{Bitset$set_difference()}}
-\item \href{#method-sample}{\code{Bitset$sample()}}
-\item \href{#method-choose}{\code{Bitset$choose()}}
-\item \href{#method-copy}{\code{Bitset$copy()}}
-\item \href{#method-to_vector}{\code{Bitset$to_vector()}}
-\item \href{#method-clone}{\code{Bitset$clone()}}
+\item \href{#method-Bitset-new}{\code{Bitset$new()}}
+\item \href{#method-Bitset-insert}{\code{Bitset$insert()}}
+\item \href{#method-Bitset-remove}{\code{Bitset$remove()}}
+\item \href{#method-Bitset-clear}{\code{Bitset$clear()}}
+\item \href{#method-Bitset-size}{\code{Bitset$size()}}
+\item \href{#method-Bitset-or}{\code{Bitset$or()}}
+\item \href{#method-Bitset-and}{\code{Bitset$and()}}
+\item \href{#method-Bitset-not}{\code{Bitset$not()}}
+\item \href{#method-Bitset-xor}{\code{Bitset$xor()}}
+\item \href{#method-Bitset-set_difference}{\code{Bitset$set_difference()}}
+\item \href{#method-Bitset-sample}{\code{Bitset$sample()}}
+\item \href{#method-Bitset-choose}{\code{Bitset$choose()}}
+\item \href{#method-Bitset-copy}{\code{Bitset$copy()}}
+\item \href{#method-Bitset-to_vector}{\code{Bitset$to_vector()}}
+\item \href{#method-Bitset-clone}{\code{Bitset$clone()}}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
+\if{html}{\out{<a id="method-Bitset-new"></a>}}
+\if{latex}{\out{\hypertarget{method-Bitset-new}{}}}
 \subsection{Method \code{new()}}{
 create a bitset.
 \subsection{Usage}{
@@ -61,8 +61,8 @@ make empty bitset, otherwise copy existing bitset.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-insert"></a>}}
-\if{latex}{\out{\hypertarget{method-insert}{}}}
+\if{html}{\out{<a id="method-Bitset-insert"></a>}}
+\if{latex}{\out{\hypertarget{method-Bitset-insert}{}}}
 \subsection{Method \code{insert()}}{
 insert into the bitset.
 \subsection{Usage}{
@@ -78,8 +78,8 @@ insert into the bitset.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-remove"></a>}}
-\if{latex}{\out{\hypertarget{method-remove}{}}}
+\if{html}{\out{<a id="method-Bitset-remove"></a>}}
+\if{latex}{\out{\hypertarget{method-Bitset-remove}{}}}
 \subsection{Method \code{remove()}}{
 remove from the bitset.
 \subsection{Usage}{
@@ -95,18 +95,18 @@ remove from the bitset.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clear"></a>}}
-\if{latex}{\out{\hypertarget{method-clear}{}}}
+\if{html}{\out{<a id="method-Bitset-clear"></a>}}
+\if{latex}{\out{\hypertarget{method-Bitset-clear}{}}}
 \subsection{Method \code{clear()}}{
 clear the bitset.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Bitset$clear(v)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Bitset$clear()}\if{html}{\out{</div>}}
 }
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-size"></a>}}
-\if{latex}{\out{\hypertarget{method-size}{}}}
+\if{html}{\out{<a id="method-Bitset-size"></a>}}
+\if{latex}{\out{\hypertarget{method-Bitset-size}{}}}
 \subsection{Method \code{size()}}{
 get the number of elements in the set.
 \subsection{Usage}{
@@ -115,8 +115,8 @@ get the number of elements in the set.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-or"></a>}}
-\if{latex}{\out{\hypertarget{method-or}{}}}
+\if{html}{\out{<a id="method-Bitset-or"></a>}}
+\if{latex}{\out{\hypertarget{method-Bitset-or}{}}}
 \subsection{Method \code{or()}}{
 to "bitwise or" or union two bitsets.
 \subsection{Usage}{
@@ -132,8 +132,8 @@ to "bitwise or" or union two bitsets.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-and"></a>}}
-\if{latex}{\out{\hypertarget{method-and}{}}}
+\if{html}{\out{<a id="method-Bitset-and"></a>}}
+\if{latex}{\out{\hypertarget{method-Bitset-and}{}}}
 \subsection{Method \code{and()}}{
 to "bitwise and" or intersect two bitsets.
 \subsection{Usage}{
@@ -149,8 +149,8 @@ to "bitwise and" or intersect two bitsets.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-not"></a>}}
-\if{latex}{\out{\hypertarget{method-not}{}}}
+\if{html}{\out{<a id="method-Bitset-not"></a>}}
+\if{latex}{\out{\hypertarget{method-Bitset-not}{}}}
 \subsection{Method \code{not()}}{
 to "bitwise not" or complement a bitset.
 \subsection{Usage}{
@@ -166,8 +166,8 @@ to "bitwise not" or complement a bitset.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-xor"></a>}}
-\if{latex}{\out{\hypertarget{method-xor}{}}}
+\if{html}{\out{<a id="method-Bitset-xor"></a>}}
+\if{latex}{\out{\hypertarget{method-Bitset-xor}{}}}
 \subsection{Method \code{xor()}}{
 to "bitwise xor" or get the symmetric difference of two bitset
 (keep elements in either bitset but not in their intersection).
@@ -184,8 +184,8 @@ to "bitwise xor" or get the symmetric difference of two bitset
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-set_difference"></a>}}
-\if{latex}{\out{\hypertarget{method-set_difference}{}}}
+\if{html}{\out{<a id="method-Bitset-set_difference"></a>}}
+\if{latex}{\out{\hypertarget{method-Bitset-set_difference}{}}}
 \subsection{Method \code{set_difference()}}{
 Take the set difference of this bitset with another
 (keep elements of this bitset which are not in \code{other}).
@@ -202,8 +202,8 @@ Take the set difference of this bitset with another
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-sample"></a>}}
-\if{latex}{\out{\hypertarget{method-sample}{}}}
+\if{html}{\out{<a id="method-Bitset-sample"></a>}}
+\if{latex}{\out{\hypertarget{method-Bitset-sample}{}}}
 \subsection{Method \code{sample()}}{
 sample a bitset.
 \subsection{Usage}{
@@ -221,8 +221,8 @@ probabilities for keeping each element.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-choose"></a>}}
-\if{latex}{\out{\hypertarget{method-choose}{}}}
+\if{html}{\out{<a id="method-Bitset-choose"></a>}}
+\if{latex}{\out{\hypertarget{method-Bitset-choose}{}}}
 \subsection{Method \code{choose()}}{
 choose k random items in the bitset
 \subsection{Usage}{
@@ -240,8 +240,8 @@ k should be chosen such that \eqn{0 \le k \le N}.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-copy"></a>}}
-\if{latex}{\out{\hypertarget{method-copy}{}}}
+\if{html}{\out{<a id="method-Bitset-copy"></a>}}
+\if{latex}{\out{\hypertarget{method-Bitset-copy}{}}}
 \subsection{Method \code{copy()}}{
 returns a copy the bitset.
 \subsection{Usage}{
@@ -250,8 +250,8 @@ returns a copy the bitset.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-to_vector"></a>}}
-\if{latex}{\out{\hypertarget{method-to_vector}{}}}
+\if{html}{\out{<a id="method-Bitset-to_vector"></a>}}
+\if{latex}{\out{\hypertarget{method-Bitset-to_vector}{}}}
 \subsection{Method \code{to_vector()}}{
 return an integer vector of the elements
 stored in this bitset.
@@ -261,8 +261,8 @@ stored in this bitset.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-clone}{}}}
+\if{html}{\out{<a id="method-Bitset-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-Bitset-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/man/CategoricalVariable.Rd
+++ b/man/CategoricalVariable.Rd
@@ -13,18 +13,22 @@ if possible because certain operations will be faster.
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{CategoricalVariable$new()}}
-\item \href{#method-get_index_of}{\code{CategoricalVariable$get_index_of()}}
-\item \href{#method-get_size_of}{\code{CategoricalVariable$get_size_of()}}
-\item \href{#method-get_categories}{\code{CategoricalVariable$get_categories()}}
-\item \href{#method-queue_update}{\code{CategoricalVariable$queue_update()}}
-\item \href{#method-.update}{\code{CategoricalVariable$.update()}}
-\item \href{#method-clone}{\code{CategoricalVariable$clone()}}
+\item \href{#method-CategoricalVariable-new}{\code{CategoricalVariable$new()}}
+\item \href{#method-CategoricalVariable-get_index_of}{\code{CategoricalVariable$get_index_of()}}
+\item \href{#method-CategoricalVariable-get_size_of}{\code{CategoricalVariable$get_size_of()}}
+\item \href{#method-CategoricalVariable-get_categories}{\code{CategoricalVariable$get_categories()}}
+\item \href{#method-CategoricalVariable-queue_update}{\code{CategoricalVariable$queue_update()}}
+\item \href{#method-CategoricalVariable-queue_extend}{\code{CategoricalVariable$queue_extend()}}
+\item \href{#method-CategoricalVariable-queue_shrink}{\code{CategoricalVariable$queue_shrink()}}
+\item \href{#method-CategoricalVariable-size}{\code{CategoricalVariable$size()}}
+\item \href{#method-CategoricalVariable-.update}{\code{CategoricalVariable$.update()}}
+\item \href{#method-CategoricalVariable-.resize}{\code{CategoricalVariable$.resize()}}
+\item \href{#method-CategoricalVariable-clone}{\code{CategoricalVariable$clone()}}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
+\if{html}{\out{<a id="method-CategoricalVariable-new"></a>}}
+\if{latex}{\out{\hypertarget{method-CategoricalVariable-new}{}}}
 \subsection{Method \code{new()}}{
 Create a new CategoricalVariable
 \subsection{Usage}{
@@ -43,8 +47,8 @@ individual}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-get_index_of"></a>}}
-\if{latex}{\out{\hypertarget{method-get_index_of}{}}}
+\if{html}{\out{<a id="method-CategoricalVariable-get_index_of"></a>}}
+\if{latex}{\out{\hypertarget{method-CategoricalVariable-get_index_of}{}}}
 \subsection{Method \code{get_index_of()}}{
 return a \code{\link[individual]{Bitset}} for individuals with the given \code{values}
 \subsection{Usage}{
@@ -60,8 +64,8 @@ return a \code{\link[individual]{Bitset}} for individuals with the given \code{v
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-get_size_of"></a>}}
-\if{latex}{\out{\hypertarget{method-get_size_of}{}}}
+\if{html}{\out{<a id="method-CategoricalVariable-get_size_of"></a>}}
+\if{latex}{\out{\hypertarget{method-CategoricalVariable-get_size_of}{}}}
 \subsection{Method \code{get_size_of()}}{
 return the number of individuals with the given \code{values}
 \subsection{Usage}{
@@ -77,8 +81,8 @@ return the number of individuals with the given \code{values}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-get_categories"></a>}}
-\if{latex}{\out{\hypertarget{method-get_categories}{}}}
+\if{html}{\out{<a id="method-CategoricalVariable-get_categories"></a>}}
+\if{latex}{\out{\hypertarget{method-CategoricalVariable-get_categories}{}}}
 \subsection{Method \code{get_categories()}}{
 return a character vector of possible values.
 Note that the order of the returned vector may not be the same order
@@ -90,8 +94,8 @@ unordered storage type.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-queue_update"></a>}}
-\if{latex}{\out{\hypertarget{method-queue_update}{}}}
+\if{html}{\out{<a id="method-CategoricalVariable-queue_update"></a>}}
+\if{latex}{\out{\hypertarget{method-CategoricalVariable-queue_update}{}}}
 \subsection{Method \code{queue_update()}}{
 queue an update for this variable
 \subsection{Usage}{
@@ -111,8 +115,52 @@ a \code{\link[individual]{Bitset}}.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-.update"></a>}}
-\if{latex}{\out{\hypertarget{method-.update}{}}}
+\if{html}{\out{<a id="method-CategoricalVariable-queue_extend"></a>}}
+\if{latex}{\out{\hypertarget{method-CategoricalVariable-queue_extend}{}}}
+\subsection{Method \code{queue_extend()}}{
+extend the variable with new values
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{CategoricalVariable$queue_extend(values)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{values}}{to add to the variable}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-CategoricalVariable-queue_shrink"></a>}}
+\if{latex}{\out{\hypertarget{method-CategoricalVariable-queue_shrink}{}}}
+\subsection{Method \code{queue_shrink()}}{
+shrink the variable
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{CategoricalVariable$queue_shrink(index)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{index}}{a bitset or vector representing the individuals to remove}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-CategoricalVariable-size"></a>}}
+\if{latex}{\out{\hypertarget{method-CategoricalVariable-size}{}}}
+\subsection{Method \code{size()}}{
+get the size of the variable
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{CategoricalVariable$size()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-CategoricalVariable-.update"></a>}}
+\if{latex}{\out{\hypertarget{method-CategoricalVariable-.update}{}}}
 \subsection{Method \code{.update()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{CategoricalVariable$.update()}\if{html}{\out{</div>}}
@@ -120,8 +168,17 @@ a \code{\link[individual]{Bitset}}.}
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-clone}{}}}
+\if{html}{\out{<a id="method-CategoricalVariable-.resize"></a>}}
+\if{latex}{\out{\hypertarget{method-CategoricalVariable-.resize}{}}}
+\subsection{Method \code{.resize()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{CategoricalVariable$.resize()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-CategoricalVariable-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-CategoricalVariable-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/man/DoubleVariable.Rd
+++ b/man/DoubleVariable.Rd
@@ -9,18 +9,22 @@ Represents a continuous variable for an individual.
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{DoubleVariable$new()}}
-\item \href{#method-get_values}{\code{DoubleVariable$get_values()}}
-\item \href{#method-get_index_of}{\code{DoubleVariable$get_index_of()}}
-\item \href{#method-get_size_of}{\code{DoubleVariable$get_size_of()}}
-\item \href{#method-queue_update}{\code{DoubleVariable$queue_update()}}
-\item \href{#method-.update}{\code{DoubleVariable$.update()}}
-\item \href{#method-clone}{\code{DoubleVariable$clone()}}
+\item \href{#method-DoubleVariable-new}{\code{DoubleVariable$new()}}
+\item \href{#method-DoubleVariable-get_values}{\code{DoubleVariable$get_values()}}
+\item \href{#method-DoubleVariable-get_index_of}{\code{DoubleVariable$get_index_of()}}
+\item \href{#method-DoubleVariable-get_size_of}{\code{DoubleVariable$get_size_of()}}
+\item \href{#method-DoubleVariable-queue_update}{\code{DoubleVariable$queue_update()}}
+\item \href{#method-DoubleVariable-queue_extend}{\code{DoubleVariable$queue_extend()}}
+\item \href{#method-DoubleVariable-queue_shrink}{\code{DoubleVariable$queue_shrink()}}
+\item \href{#method-DoubleVariable-size}{\code{DoubleVariable$size()}}
+\item \href{#method-DoubleVariable-.update}{\code{DoubleVariable$.update()}}
+\item \href{#method-DoubleVariable-.resize}{\code{DoubleVariable$.resize()}}
+\item \href{#method-DoubleVariable-clone}{\code{DoubleVariable$clone()}}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
+\if{html}{\out{<a id="method-DoubleVariable-new"></a>}}
+\if{latex}{\out{\hypertarget{method-DoubleVariable-new}{}}}
 \subsection{Method \code{new()}}{
 Create a new DoubleVariable.
 \subsection{Usage}{
@@ -37,8 +41,8 @@ individual.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-get_values"></a>}}
-\if{latex}{\out{\hypertarget{method-get_values}{}}}
+\if{html}{\out{<a id="method-DoubleVariable-get_values"></a>}}
+\if{latex}{\out{\hypertarget{method-DoubleVariable-get_values}{}}}
 \subsection{Method \code{get_values()}}{
 get the variable values.
 \subsection{Usage}{
@@ -56,10 +60,10 @@ or integer vector, return values of those individuals.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-get_index_of"></a>}}
-\if{latex}{\out{\hypertarget{method-get_index_of}{}}}
+\if{html}{\out{<a id="method-DoubleVariable-get_index_of"></a>}}
+\if{latex}{\out{\hypertarget{method-DoubleVariable-get_index_of}{}}}
 \subsection{Method \code{get_index_of()}}{
-return a \code{\link[individual]{Bitset}} giving individuals 
+return a \code{\link[individual]{Bitset}} giving individuals
 whose value lies in an interval \eqn{[a,b]}.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{DoubleVariable$get_index_of(a, b)}\if{html}{\out{</div>}}
@@ -76,8 +80,8 @@ whose value lies in an interval \eqn{[a,b]}.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-get_size_of"></a>}}
-\if{latex}{\out{\hypertarget{method-get_size_of}{}}}
+\if{html}{\out{<a id="method-DoubleVariable-get_size_of"></a>}}
+\if{latex}{\out{\hypertarget{method-DoubleVariable-get_size_of}{}}}
 \subsection{Method \code{get_size_of()}}{
 return the number of individuals whose value lies in an interval
 Count individuals whose value lies in an interval \eqn{[a,b]}.
@@ -96,8 +100,8 @@ Count individuals whose value lies in an interval \eqn{[a,b]}.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-queue_update"></a>}}
-\if{latex}{\out{\hypertarget{method-queue_update}{}}}
+\if{html}{\out{<a id="method-DoubleVariable-queue_update"></a>}}
+\if{latex}{\out{\hypertarget{method-DoubleVariable-queue_update}{}}}
 \subsection{Method \code{queue_update()}}{
 Queue an update for a variable. There are 4 types of variable update:
 \enumerate{
@@ -111,7 +115,7 @@ replaces all of the current values in the simulation. \code{values} should be a 
 whose length should match the size of the population, which fills all the variable values in
 the population}
  \item{Variable fill: }{The index vector is set to \code{NULL} and the argument \code{values}
-should be a single number, which fills all of the variable values in 
+should be a single number, which fills all of the variable values in
 the population.}
 }
 \subsection{Usage}{
@@ -131,8 +135,52 @@ a \code{\link[individual]{Bitset}}.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-.update"></a>}}
-\if{latex}{\out{\hypertarget{method-.update}{}}}
+\if{html}{\out{<a id="method-DoubleVariable-queue_extend"></a>}}
+\if{latex}{\out{\hypertarget{method-DoubleVariable-queue_extend}{}}}
+\subsection{Method \code{queue_extend()}}{
+extend the variable with new values
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{DoubleVariable$queue_extend(values)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{values}}{to add to the variable}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-DoubleVariable-queue_shrink"></a>}}
+\if{latex}{\out{\hypertarget{method-DoubleVariable-queue_shrink}{}}}
+\subsection{Method \code{queue_shrink()}}{
+shrink the variable
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{DoubleVariable$queue_shrink(index)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{index}}{a bitset or vector representing the individuals to remove}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-DoubleVariable-size"></a>}}
+\if{latex}{\out{\hypertarget{method-DoubleVariable-size}{}}}
+\subsection{Method \code{size()}}{
+get the size of the variable
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{DoubleVariable$size()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-DoubleVariable-.update"></a>}}
+\if{latex}{\out{\hypertarget{method-DoubleVariable-.update}{}}}
 \subsection{Method \code{.update()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{DoubleVariable$.update()}\if{html}{\out{</div>}}
@@ -140,8 +188,17 @@ a \code{\link[individual]{Bitset}}.}
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-clone}{}}}
+\if{html}{\out{<a id="method-DoubleVariable-.resize"></a>}}
+\if{latex}{\out{\hypertarget{method-DoubleVariable-.resize}{}}}
+\subsection{Method \code{.resize()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{DoubleVariable$.resize()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-DoubleVariable-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-DoubleVariable-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/man/Event.Rd
+++ b/man/Event.Rd
@@ -9,20 +9,21 @@ Describes a general event in the simulation.
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{Event$new()}}
-\item \href{#method-add_listener}{\code{Event$add_listener()}}
-\item \href{#method-schedule}{\code{Event$schedule()}}
-\item \href{#method-clear_schedule}{\code{Event$clear_schedule()}}
-\item \href{#method-.tick}{\code{Event$.tick()}}
-\item \href{#method-.process}{\code{Event$.process()}}
-\item \href{#method-.process_listener}{\code{Event$.process_listener()}}
-\item \href{#method-.process_listener_cpp}{\code{Event$.process_listener_cpp()}}
-\item \href{#method-clone}{\code{Event$clone()}}
+\item \href{#method-Event-new}{\code{Event$new()}}
+\item \href{#method-Event-add_listener}{\code{Event$add_listener()}}
+\item \href{#method-Event-schedule}{\code{Event$schedule()}}
+\item \href{#method-Event-clear_schedule}{\code{Event$clear_schedule()}}
+\item \href{#method-Event-.tick}{\code{Event$.tick()}}
+\item \href{#method-Event-.process}{\code{Event$.process()}}
+\item \href{#method-Event-.process_listener}{\code{Event$.process_listener()}}
+\item \href{#method-Event-.process_listener_cpp}{\code{Event$.process_listener_cpp()}}
+\item \href{#method-Event-.resize}{\code{Event$.resize()}}
+\item \href{#method-Event-clone}{\code{Event$clone()}}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
+\if{html}{\out{<a id="method-Event-new"></a>}}
+\if{latex}{\out{\hypertarget{method-Event-new}{}}}
 \subsection{Method \code{new()}}{
 Initialise an Event.
 \subsection{Usage}{
@@ -31,8 +32,8 @@ Initialise an Event.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-add_listener"></a>}}
-\if{latex}{\out{\hypertarget{method-add_listener}{}}}
+\if{html}{\out{<a id="method-Event-add_listener"></a>}}
+\if{latex}{\out{\hypertarget{method-Event-add_listener}{}}}
 \subsection{Method \code{add_listener()}}{
 Add an event listener.
 \subsection{Usage}{
@@ -49,8 +50,8 @@ argument giving the time step when this event is triggered.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-schedule"></a>}}
-\if{latex}{\out{\hypertarget{method-schedule}{}}}
+\if{html}{\out{<a id="method-Event-schedule"></a>}}
+\if{latex}{\out{\hypertarget{method-Event-schedule}{}}}
 \subsection{Method \code{schedule()}}{
 Schedule this event to occur in the future.
 \subsection{Usage}{
@@ -68,8 +69,8 @@ multiple times.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clear_schedule"></a>}}
-\if{latex}{\out{\hypertarget{method-clear_schedule}{}}}
+\if{html}{\out{<a id="method-Event-clear_schedule"></a>}}
+\if{latex}{\out{\hypertarget{method-Event-clear_schedule}{}}}
 \subsection{Method \code{clear_schedule()}}{
 Stop a future event from triggering.
 \subsection{Usage}{
@@ -78,8 +79,8 @@ Stop a future event from triggering.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-.tick"></a>}}
-\if{latex}{\out{\hypertarget{method-.tick}{}}}
+\if{html}{\out{<a id="method-Event-.tick"></a>}}
+\if{latex}{\out{\hypertarget{method-Event-.tick}{}}}
 \subsection{Method \code{.tick()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Event$.tick()}\if{html}{\out{</div>}}
@@ -87,8 +88,8 @@ Stop a future event from triggering.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-.process"></a>}}
-\if{latex}{\out{\hypertarget{method-.process}{}}}
+\if{html}{\out{<a id="method-Event-.process"></a>}}
+\if{latex}{\out{\hypertarget{method-Event-.process}{}}}
 \subsection{Method \code{.process()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Event$.process()}\if{html}{\out{</div>}}
@@ -96,8 +97,8 @@ Stop a future event from triggering.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-.process_listener"></a>}}
-\if{latex}{\out{\hypertarget{method-.process_listener}{}}}
+\if{html}{\out{<a id="method-Event-.process_listener"></a>}}
+\if{latex}{\out{\hypertarget{method-Event-.process_listener}{}}}
 \subsection{Method \code{.process_listener()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Event$.process_listener(listener)}\if{html}{\out{</div>}}
@@ -105,8 +106,8 @@ Stop a future event from triggering.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-.process_listener_cpp"></a>}}
-\if{latex}{\out{\hypertarget{method-.process_listener_cpp}{}}}
+\if{html}{\out{<a id="method-Event-.process_listener_cpp"></a>}}
+\if{latex}{\out{\hypertarget{method-Event-.process_listener_cpp}{}}}
 \subsection{Method \code{.process_listener_cpp()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Event$.process_listener_cpp(listener)}\if{html}{\out{</div>}}
@@ -114,8 +115,17 @@ Stop a future event from triggering.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-clone}{}}}
+\if{html}{\out{<a id="method-Event-.resize"></a>}}
+\if{latex}{\out{\hypertarget{method-Event-.resize}{}}}
+\subsection{Method \code{.resize()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Event$.resize()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Event-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-Event-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/man/IntegerVariable.Rd
+++ b/man/IntegerVariable.Rd
@@ -13,18 +13,22 @@ household or age bin.
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{IntegerVariable$new()}}
-\item \href{#method-get_values}{\code{IntegerVariable$get_values()}}
-\item \href{#method-get_index_of}{\code{IntegerVariable$get_index_of()}}
-\item \href{#method-get_size_of}{\code{IntegerVariable$get_size_of()}}
-\item \href{#method-queue_update}{\code{IntegerVariable$queue_update()}}
-\item \href{#method-.update}{\code{IntegerVariable$.update()}}
-\item \href{#method-clone}{\code{IntegerVariable$clone()}}
+\item \href{#method-IntegerVariable-new}{\code{IntegerVariable$new()}}
+\item \href{#method-IntegerVariable-get_values}{\code{IntegerVariable$get_values()}}
+\item \href{#method-IntegerVariable-get_index_of}{\code{IntegerVariable$get_index_of()}}
+\item \href{#method-IntegerVariable-get_size_of}{\code{IntegerVariable$get_size_of()}}
+\item \href{#method-IntegerVariable-queue_update}{\code{IntegerVariable$queue_update()}}
+\item \href{#method-IntegerVariable-queue_extend}{\code{IntegerVariable$queue_extend()}}
+\item \href{#method-IntegerVariable-queue_shrink}{\code{IntegerVariable$queue_shrink()}}
+\item \href{#method-IntegerVariable-size}{\code{IntegerVariable$size()}}
+\item \href{#method-IntegerVariable-.update}{\code{IntegerVariable$.update()}}
+\item \href{#method-IntegerVariable-.resize}{\code{IntegerVariable$.resize()}}
+\item \href{#method-IntegerVariable-clone}{\code{IntegerVariable$clone()}}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
+\if{html}{\out{<a id="method-IntegerVariable-new"></a>}}
+\if{latex}{\out{\hypertarget{method-IntegerVariable-new}{}}}
 \subsection{Method \code{new()}}{
 Create a new IntegerVariable.
 \subsection{Usage}{
@@ -40,8 +44,8 @@ Create a new IntegerVariable.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-get_values"></a>}}
-\if{latex}{\out{\hypertarget{method-get_values}{}}}
+\if{html}{\out{<a id="method-IntegerVariable-get_values"></a>}}
+\if{latex}{\out{\hypertarget{method-IntegerVariable-get_values}{}}}
 \subsection{Method \code{get_values()}}{
 Get the variable values.
 \subsection{Usage}{
@@ -59,8 +63,8 @@ or integer vector, return values of those individuals.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-get_index_of"></a>}}
-\if{latex}{\out{\hypertarget{method-get_index_of}{}}}
+\if{html}{\out{<a id="method-IntegerVariable-get_index_of"></a>}}
+\if{latex}{\out{\hypertarget{method-IntegerVariable-get_index_of}{}}}
 \subsection{Method \code{get_index_of()}}{
 Return a \code{\link[individual]{Bitset}} for individuals with some subset of values.
 Either search for indices corresponding to values in \code{set}, or
@@ -83,8 +87,8 @@ or \code{a} and \code{b} must be provided as arguments.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-get_size_of"></a>}}
-\if{latex}{\out{\hypertarget{method-get_size_of}{}}}
+\if{html}{\out{<a id="method-IntegerVariable-get_size_of"></a>}}
+\if{latex}{\out{\hypertarget{method-IntegerVariable-get_size_of}{}}}
 \subsection{Method \code{get_size_of()}}{
 Return the number of individuals with some subset of values.
 Either search for indices corresponding to values in \code{set}, or
@@ -107,8 +111,8 @@ or \code{a} and \code{b} must be provided as arguments.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-queue_update"></a>}}
-\if{latex}{\out{\hypertarget{method-queue_update}{}}}
+\if{html}{\out{<a id="method-IntegerVariable-queue_update"></a>}}
+\if{latex}{\out{\hypertarget{method-IntegerVariable-queue_update}{}}}
 \subsection{Method \code{queue_update()}}{
 Queue an update for a variable. There are 4 types of variable update:
 
@@ -123,7 +127,7 @@ replaces all of the current values in the simulation. \code{values} should be a 
 whose length should match the size of the population, which fills all the variable values in
 the population}
  \item{Variable fill: }{The index vector is set to \code{NULL} and the argument \code{values}
-should be a single number, which fills all of the variable values in 
+should be a single number, which fills all of the variable values in
 the population.}
 }
 \subsection{Usage}{
@@ -143,8 +147,52 @@ a \code{\link[individual]{Bitset}}.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-.update"></a>}}
-\if{latex}{\out{\hypertarget{method-.update}{}}}
+\if{html}{\out{<a id="method-IntegerVariable-queue_extend"></a>}}
+\if{latex}{\out{\hypertarget{method-IntegerVariable-queue_extend}{}}}
+\subsection{Method \code{queue_extend()}}{
+extend the variable with new values
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{IntegerVariable$queue_extend(values)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{values}}{to add to the variable}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-IntegerVariable-queue_shrink"></a>}}
+\if{latex}{\out{\hypertarget{method-IntegerVariable-queue_shrink}{}}}
+\subsection{Method \code{queue_shrink()}}{
+shrink the variable
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{IntegerVariable$queue_shrink(index)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{index}}{a bitset or vector representing the individuals to remove}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-IntegerVariable-size"></a>}}
+\if{latex}{\out{\hypertarget{method-IntegerVariable-size}{}}}
+\subsection{Method \code{size()}}{
+get the size of the variable
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{IntegerVariable$size()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-IntegerVariable-.update"></a>}}
+\if{latex}{\out{\hypertarget{method-IntegerVariable-.update}{}}}
 \subsection{Method \code{.update()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{IntegerVariable$.update()}\if{html}{\out{</div>}}
@@ -152,8 +200,17 @@ a \code{\link[individual]{Bitset}}.}
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-clone}{}}}
+\if{html}{\out{<a id="method-IntegerVariable-.resize"></a>}}
+\if{latex}{\out{\hypertarget{method-IntegerVariable-.resize}{}}}
+\subsection{Method \code{.resize()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{IntegerVariable$.resize()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-IntegerVariable-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-IntegerVariable-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/man/Render.Rd
+++ b/man/Render.Rd
@@ -9,16 +9,16 @@ Class to render output for the simulation.
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{Render$new()}}
-\item \href{#method-set_default}{\code{Render$set_default()}}
-\item \href{#method-render}{\code{Render$render()}}
-\item \href{#method-to_dataframe}{\code{Render$to_dataframe()}}
-\item \href{#method-clone}{\code{Render$clone()}}
+\item \href{#method-Render-new}{\code{Render$new()}}
+\item \href{#method-Render-set_default}{\code{Render$set_default()}}
+\item \href{#method-Render-render}{\code{Render$render()}}
+\item \href{#method-Render-to_dataframe}{\code{Render$to_dataframe()}}
+\item \href{#method-Render-clone}{\code{Render$clone()}}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
+\if{html}{\out{<a id="method-Render-new"></a>}}
+\if{latex}{\out{\hypertarget{method-Render-new}{}}}
 \subsection{Method \code{new()}}{
 Initialise a renderer for the simulation, creates the default state
 renderers.
@@ -35,8 +35,8 @@ renderers.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-set_default"></a>}}
-\if{latex}{\out{\hypertarget{method-set_default}{}}}
+\if{html}{\out{<a id="method-Render-set_default"></a>}}
+\if{latex}{\out{\hypertarget{method-Render-set_default}{}}}
 \subsection{Method \code{set_default()}}{
 Set a default value for a rendered output
 renderers.
@@ -55,8 +55,8 @@ renderers.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-render"></a>}}
-\if{latex}{\out{\hypertarget{method-render}{}}}
+\if{html}{\out{<a id="method-Render-render"></a>}}
+\if{latex}{\out{\hypertarget{method-Render-render}{}}}
 \subsection{Method \code{render()}}{
 Update the render with new simulation data.
 \subsection{Usage}{
@@ -76,8 +76,8 @@ Update the render with new simulation data.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-to_dataframe"></a>}}
-\if{latex}{\out{\hypertarget{method-to_dataframe}{}}}
+\if{html}{\out{<a id="method-Render-to_dataframe"></a>}}
+\if{latex}{\out{\hypertarget{method-Render-to_dataframe}{}}}
 \subsection{Method \code{to_dataframe()}}{
 Return the render as a \code{\link[base]{data.frame}}.
 \subsection{Usage}{
@@ -86,8 +86,8 @@ Return the render as a \code{\link[base]{data.frame}}.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-clone}{}}}
+\if{html}{\out{<a id="method-Render-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-Render-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/man/TargetedEvent.Rd
+++ b/man/TargetedEvent.Rd
@@ -13,27 +13,31 @@ This is useful for events which are triggered for a sub-population.
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{TargetedEvent$new()}}
-\item \href{#method-schedule}{\code{TargetedEvent$schedule()}}
-\item \href{#method-get_scheduled}{\code{TargetedEvent$get_scheduled()}}
-\item \href{#method-clear_schedule}{\code{TargetedEvent$clear_schedule()}}
-\item \href{#method-.process_listener}{\code{TargetedEvent$.process_listener()}}
-\item \href{#method-.process_listener_cpp}{\code{TargetedEvent$.process_listener_cpp()}}
-\item \href{#method-clone}{\code{TargetedEvent$clone()}}
+\item \href{#method-TargetedEvent-new}{\code{TargetedEvent$new()}}
+\item \href{#method-TargetedEvent-schedule}{\code{TargetedEvent$schedule()}}
+\item \href{#method-TargetedEvent-get_scheduled}{\code{TargetedEvent$get_scheduled()}}
+\item \href{#method-TargetedEvent-clear_schedule}{\code{TargetedEvent$clear_schedule()}}
+\item \href{#method-TargetedEvent-queue_extend}{\code{TargetedEvent$queue_extend()}}
+\item \href{#method-TargetedEvent-queue_extend_with_schedule}{\code{TargetedEvent$queue_extend_with_schedule()}}
+\item \href{#method-TargetedEvent-queue_shrink}{\code{TargetedEvent$queue_shrink()}}
+\item \href{#method-TargetedEvent-.process_listener}{\code{TargetedEvent$.process_listener()}}
+\item \href{#method-TargetedEvent-.process_listener_cpp}{\code{TargetedEvent$.process_listener_cpp()}}
+\item \href{#method-TargetedEvent-.resize}{\code{TargetedEvent$.resize()}}
+\item \href{#method-TargetedEvent-clone}{\code{TargetedEvent$clone()}}
 }
 }
-\if{html}{
-\out{<details open ><summary>Inherited methods</summary>}
-\itemize{
-\item \out{<span class="pkg-link" data-pkg="individual" data-topic="Event" data-id=".process">}\href{../../individual/html/Event.html#method-.process}{\code{individual::Event$.process()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="individual" data-topic="Event" data-id=".tick">}\href{../../individual/html/Event.html#method-.tick}{\code{individual::Event$.tick()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="individual" data-topic="Event" data-id="add_listener">}\href{../../individual/html/Event.html#method-add_listener}{\code{individual::Event$add_listener()}}\out{</span>}
-}
-\out{</details>}
-}
+\if{html}{\out{
+<details open><summary>Inherited methods</summary>
+<ul>
+<li><span class="pkg-link" data-pkg="individual" data-topic="Event" data-id=".process"><a href='../../individual/html/Event.html#method-Event-.process'><code>individual::Event$.process()</code></a></li>
+<li><span class="pkg-link" data-pkg="individual" data-topic="Event" data-id=".tick"><a href='../../individual/html/Event.html#method-Event-.tick'><code>individual::Event$.tick()</code></a></li>
+<li><span class="pkg-link" data-pkg="individual" data-topic="Event" data-id="add_listener"><a href='../../individual/html/Event.html#method-Event-add_listener'><code>individual::Event$add_listener()</code></a></li>
+</ul>
+</details>
+}}
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
+\if{html}{\out{<a id="method-TargetedEvent-new"></a>}}
+\if{latex}{\out{\hypertarget{method-TargetedEvent-new}{}}}
 \subsection{Method \code{new()}}{
 Initialise a TargetedEvent.
 \subsection{Usage}{
@@ -49,8 +53,8 @@ Initialise a TargetedEvent.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-schedule"></a>}}
-\if{latex}{\out{\hypertarget{method-schedule}{}}}
+\if{html}{\out{<a id="method-TargetedEvent-schedule"></a>}}
+\if{latex}{\out{\hypertarget{method-TargetedEvent-schedule}{}}}
 \subsection{Method \code{schedule()}}{
 Schedule this event to occur in the future.
 \subsection{Usage}{
@@ -60,7 +64,7 @@ Schedule this event to occur in the future.
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{target}}{the individuals to pass to the listener, this may be 
+\item{\code{target}}{the individuals to pass to the listener, this may be
 either a vector of integers or a \code{\link[individual]{Bitset}}.}
 
 \item{\code{delay}}{the number of time steps to wait before triggering the event,
@@ -72,8 +76,8 @@ individual.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-get_scheduled"></a>}}
-\if{latex}{\out{\hypertarget{method-get_scheduled}{}}}
+\if{html}{\out{<a id="method-TargetedEvent-get_scheduled"></a>}}
+\if{latex}{\out{\hypertarget{method-TargetedEvent-get_scheduled}{}}}
 \subsection{Method \code{get_scheduled()}}{
 Get the individuals who are scheduled as a \code{\link[individual]{Bitset}}.
 \subsection{Usage}{
@@ -82,8 +86,8 @@ Get the individuals who are scheduled as a \code{\link[individual]{Bitset}}.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clear_schedule"></a>}}
-\if{latex}{\out{\hypertarget{method-clear_schedule}{}}}
+\if{html}{\out{<a id="method-TargetedEvent-clear_schedule"></a>}}
+\if{latex}{\out{\hypertarget{method-TargetedEvent-clear_schedule}{}}}
 \subsection{Method \code{clear_schedule()}}{
 Stop a future event from triggering for a subset of individuals.
 \subsection{Usage}{
@@ -100,8 +104,59 @@ a \code{\link[individual]{Bitset}}.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-.process_listener"></a>}}
-\if{latex}{\out{\hypertarget{method-.process_listener}{}}}
+\if{html}{\out{<a id="method-TargetedEvent-queue_extend"></a>}}
+\if{latex}{\out{\hypertarget{method-TargetedEvent-queue_extend}{}}}
+\subsection{Method \code{queue_extend()}}{
+Extend the target size
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{TargetedEvent$queue_extend(n)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{n}}{the number of new elements to add to the index}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-TargetedEvent-queue_extend_with_schedule"></a>}}
+\if{latex}{\out{\hypertarget{method-TargetedEvent-queue_extend_with_schedule}{}}}
+\subsection{Method \code{queue_extend_with_schedule()}}{
+Extend the target size and schedule for the new population
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{TargetedEvent$queue_extend_with_schedule(delays)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{delays}}{the delay for each new individual}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-TargetedEvent-queue_shrink"></a>}}
+\if{latex}{\out{\hypertarget{method-TargetedEvent-queue_shrink}{}}}
+\subsection{Method \code{queue_shrink()}}{
+Shrink the targeted event
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{TargetedEvent$queue_shrink(index)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{index}}{the individuals to remove from the event}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-TargetedEvent-.process_listener"></a>}}
+\if{latex}{\out{\hypertarget{method-TargetedEvent-.process_listener}{}}}
 \subsection{Method \code{.process_listener()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{TargetedEvent$.process_listener(listener)}\if{html}{\out{</div>}}
@@ -109,8 +164,8 @@ a \code{\link[individual]{Bitset}}.}
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-.process_listener_cpp"></a>}}
-\if{latex}{\out{\hypertarget{method-.process_listener_cpp}{}}}
+\if{html}{\out{<a id="method-TargetedEvent-.process_listener_cpp"></a>}}
+\if{latex}{\out{\hypertarget{method-TargetedEvent-.process_listener_cpp}{}}}
 \subsection{Method \code{.process_listener_cpp()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{TargetedEvent$.process_listener_cpp(listener)}\if{html}{\out{</div>}}
@@ -118,8 +173,17 @@ a \code{\link[individual]{Bitset}}.}
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-clone}{}}}
+\if{html}{\out{<a id="method-TargetedEvent-.resize"></a>}}
+\if{latex}{\out{\hypertarget{method-TargetedEvent-.resize}{}}}
+\subsection{Method \code{.resize()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{TargetedEvent$.resize()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-TargetedEvent-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-TargetedEvent-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/vignettes/Changing_Populations.Rmd
+++ b/vignettes/Changing_Populations.Rmd
@@ -69,13 +69,13 @@ health_render_process <- categorical_count_renderer_process(
 
 ## Resizing variables
 
-As of individual v0.1.8, all variables and targeted events can be extended and shrunk. Extending a variable requires the user to specify new values to add to the of the variable. This can be used to model births in a population. Shrinking a variable requires the user to specify which indices to remove, the indices of subsequent values will be shifted downwards to replace the removed element. This can be used to model deaths or displacement from a population.
+As of individual v0.1.8, all variables and targeted events can be extended and shrunk. Extending a variable requires the user to specify new values to add to the end of the variable. This can be used to model births in a population. Shrinking a variable requires the user to specify which indices to remove, the indices of subsequent values will be shifted downwards to replace the removed element. This can be used to model deaths or displacement from a population.
 
 Targeted events can similarly be resized to match a changing population. You can simply add new individuals with `$queue_extend`. If you would like to schedule the event for new individuals, you can use `$queue_extend_with_schedule` with a vector of delays to make sure the event is triggered for new individuals.
 
 Resizing updates, shrinking and extending, are queued until after all processes *and* event listeners are executed and are applied after other updates. All the shrink updates for a variable or event are combined and are applied before extend updates. This ensures that the indices used to shrink a variable are the correct size for the variable. After which, extension updates are applied in the order they were called.
 
-From a performance perspective, shrinking updates should be used sparingly, since the re-indexing of a variable can be computationally expensive than other updates. Consider applying shrinking updates over longer intervals instead of every time step if performance becomes an issue for your model.
+From a performance perspective, shrinking updates should be used sparingly, since the re-indexing of a variable can be more computationally expensive than other updates. Consider applying shrinking updates over longer intervals instead of every time step if performance becomes an issue for your model.
 
 ## Birth and death processes
 


### PR DESCRIPTION
@giovannic this PR does:

* fixed 2 missing words in the new vignette
* removed the unused argument `v` in `Bitset$clear()`
* check for `NULL` input in `Bitset$sample()`; needed to get tests to pass
* check full `NULL` input in `DoubleVariable$queue_update()`; needed to get tests to pass
* check full `NULL` input in `IntegerVariable$queue_update()`; needed to get tests to pass
* remove unneeded argument passed to `.process_listener_cpp()` in `Event$.process()`
* remove unneeded `:::` in `TargetedEvent$.process_listener_cpp()`

These were all  things I noticed while reviewing #116. 