### PR TITLE
Bugfix/html errors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,6 +45,7 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 URL: https://github.com/mrc-ide/individual, https://mrc-ide.github.io/individual/
 BugReports: https://github.com/mrc-ide/individual/issues
+Roxygen: list(markdown = TRUE)
 Imports:
   R6,
   Rcpp
@@ -57,7 +58,7 @@ Suggests:
     testthat (>= 2.1.0),
     xml2,
     bench
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1.9000
 VignetteBuilder: knitr
 LinkingTo:
   Rcpp,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# individual 0.1.10
+
+  * Vector-based updates are consolidated into one place
+  * Resizing memory bug fixed
+  * Simplifed RaggedVariable instantiations to aliases until implementations are implemented
+    
 # individual 0.1.9
 
   * All variables and targeted events are resizable

--- a/R/targeted_event.R
+++ b/R/targeted_event.R
@@ -7,6 +7,7 @@ TargetedEvent <- R6Class(
   'TargetedEvent',
   inherit = Event,
   public = list(
+
     #' @description Initialise a TargetedEvent.
     #' @param population_size the size of the population.
     initialize = function(population_size) {
@@ -15,7 +16,7 @@ TargetedEvent <- R6Class(
 
     #' @description Schedule this event to occur in the future.
     #' @param target the individuals to pass to the listener, this may be
-    #' either a vector of integers or a \code{\link[individual]{Bitset}}.
+    #' either a vector of integers or a [individual::Bitset].
     #' @param delay the number of time steps to wait before triggering the event,
     #' can be a scalar in which case all targeted individuals are scheduled for
     #' for the same delay or a vector of values giving the delay for that
@@ -50,14 +51,14 @@ TargetedEvent <- R6Class(
       }
     },
 
-    #' @description Get the individuals who are scheduled as a \code{\link[individual]{Bitset}}.
+    #' @description Get the individuals who are scheduled as a [individual::Bitset].
     get_scheduled = function() {
       Bitset$new(from = targeted_event_get_scheduled(self$.event))
     },
 
     #' @description Stop a future event from triggering for a subset of individuals.
     #' @param target the individuals to clear, this may be either a vector of integers or
-    #' a \code{\link[individual]{Bitset}}.
+    #' a [individual::Bitset].
     clear_schedule = function(target) {
       if (inherits(target, "Bitset")){
         targeted_event_clear_schedule(self$.event, target$.bitset)
@@ -66,23 +67,23 @@ TargetedEvent <- R6Class(
       }
     },
 
-    #' @description Extend the target size
-    #' @param n the number of new elements to add to the index
+    #' @description Extend the target size.
+    #' @param n the number of new elements to add to the index.
     queue_extend = function(n) {
       stopifnot(is.finite(n))
       stopifnot(n > 0)
       targeted_event_queue_extend(self$.event, n)
     },
 
-    #' @description Extend the target size and schedule for the new population
-    #' @param delays the delay for each new individual
+    #' @description Extend the target size and schedule for the new population.
+    #' @param delays the delay for each new individual.
     queue_extend_with_schedule = function(delays) {
       stopifnot(is.finite(delays))
       targeted_event_queue_extend_with_schedule(self$.event, delays)
     },
 
-    #' @description Shrink the targeted event
-    #' @param index the individuals to remove from the event
+    #' @description Shrink the TargetedEvent.
+    #' @param index the individuals to remove from the event.
     queue_shrink = function(index) {
       if (inherits(index, 'Bitset')) {
         if (index$size() > 0){

--- a/man/CategoricalVariable.Rd
+++ b/man/CategoricalVariable.Rd
@@ -5,7 +5,7 @@
 \title{CategoricalVariable Class}
 \description{
 Represents a categorical variable for an individual.
-This class should be used for discrete variables taking values in 
+This class should be used for discrete variables taking values in
 a finite set, such as infection, health, or behavioral state. It should
 be used in preference to \code{\link[individual]{IntegerVariable}}
 if possible because certain operations will be faster.

--- a/man/DoubleVariable.Rd
+++ b/man/DoubleVariable.Rd
@@ -105,16 +105,16 @@ Count individuals whose value lies in an interval \eqn{[a,b]}.
 \subsection{Method \code{queue_update()}}{
 Queue an update for a variable. There are 4 types of variable update:
 \enumerate{
- \item{Subset update: }{The argument \code{index} represents a subset of the variable to
+\item{Subset update: }{The argument \code{index} represents a subset of the variable to
 update. The argument \code{values} should be a vector whose length matches the size of \code{index},
 which represents the new values for that subset.}
- \item{Subset fill: }{The argument \code{index} represents a subset of the variable to
+\item{Subset fill: }{The argument \code{index} represents a subset of the variable to
 update. The argument \code{values} should be a single number, which fills the specified subset.}
- \item{Variable reset: }{The index vector is set to \code{NULL} and the argument \code{values}
+\item{Variable reset: }{The index vector is set to \code{NULL} and the argument \code{values}
 replaces all of the current values in the simulation. \code{values} should be a vector
 whose length should match the size of the population, which fills all the variable values in
 the population}
- \item{Variable fill: }{The index vector is set to \code{NULL} and the argument \code{values}
+\item{Variable fill: }{The index vector is set to \code{NULL} and the argument \code{values}
 should be a single number, which fills all of the variable values in
 the population.}
 }

--- a/man/IntegerVariable.Rd
+++ b/man/IntegerVariable.Rd
@@ -117,16 +117,16 @@ or \code{a} and \code{b} must be provided as arguments.
 Queue an update for a variable. There are 4 types of variable update:
 
 \enumerate{
- \item{Subset update: }{The argument \code{index} represents a subset of the variable to
+\item{Subset update: }{The argument \code{index} represents a subset of the variable to
 update. The argument \code{values} should be a vector whose length matches the size of \code{index},
 which represents the new values for that subset.}
- \item{Subset fill: }{The argument \code{index} represents a subset of the variable to
+\item{Subset fill: }{The argument \code{index} represents a subset of the variable to
 update. The argument \code{values} should be a single number, which fills the specified subset.}
- \item{Variable reset: }{The index vector is set to \code{NULL} and the argument \code{values}
+\item{Variable reset: }{The index vector is set to \code{NULL} and the argument \code{values}
 replaces all of the current values in the simulation. \code{values} should be a vector
 whose length should match the size of the population, which fills all the variable values in
 the population}
- \item{Variable fill: }{The index vector is set to \code{NULL} and the argument \code{values}
+\item{Variable fill: }{The index vector is set to \code{NULL} and the argument \code{values}
 should be a single number, which fills all of the variable values in
 the population.}
 }

--- a/man/RaggedDouble.Rd
+++ b/man/RaggedDouble.Rd
@@ -51,7 +51,7 @@ Get the variable values.
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{index}}{optionally return a subset of the variable vector. If
-\code{NULL}, return all values; if passed an [individual::Bitset]
+\code{NULL}, return all values; if passed an \link{Bitset}
 or integer vector, return values of those individuals.}
 }
 \if{html}{\out{</div>}}
@@ -70,7 +70,7 @@ Get the lengths of the indiviudal elements in the ragged array
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{index}}{optionally only get lengths for a subset of persons. If
-\code{NULL}, return all lengths; if passed an [individual::Bitset]
+\code{NULL}, return all lengths; if passed an \link{Bitset}
 or integer vector, return lengths of arrays for those individuals.}
 }
 \if{html}{\out{</div>}}
@@ -83,16 +83,16 @@ or integer vector, return lengths of arrays for those individuals.}
 Queue an update for a variable. There are 4 types of variable update:
 
 \enumerate{
- \item{Subset update: }{The argument \code{index} represents a subset of the variable to
+\item{Subset update: }{The argument \code{index} represents a subset of the variable to
 update. The argument \code{values} should be a vector whose length matches the size of \code{index},
 which represents the new values for that subset.}
- \item{Subset fill: }{The argument \code{index} represents a subset of the variable to
+\item{Subset fill: }{The argument \code{index} represents a subset of the variable to
 update. The argument \code{values} should be a single number, which fills the specified subset.}
- \item{Variable reset: }{The index vector is set to \code{NULL} and the argument \code{values}
+\item{Variable reset: }{The index vector is set to \code{NULL} and the argument \code{values}
 replaces all of the current values in the simulation. \code{values} should be a vector
 whose length should match the size of the population, which fills all the variable values in
 the population}
- \item{Variable fill: }{The index vector is set to \code{NULL} and the argument \code{values}
+\item{Variable fill: }{The index vector is set to \code{NULL} and the argument \code{values}
 should be a single number, which fills all of the variable values in
 the population.}
 }
@@ -107,7 +107,7 @@ the population.}
 
 \item{\code{index}}{is the index at which to apply the change, use \code{NULL} for the
 fill options. If using indices, this may be either a vector of integers or
-an [individual::Bitset].}
+an \link{Bitset}.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/RaggedInteger.Rd
+++ b/man/RaggedInteger.Rd
@@ -51,7 +51,7 @@ Get the variable values.
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{index}}{optionally return a subset of the variable vector. If
-\code{NULL}, return all values; if passed an [individual::Bitset]
+\code{NULL}, return all values; if passed an \link{Bitset}
 or integer vector, return values of those individuals.}
 }
 \if{html}{\out{</div>}}
@@ -70,7 +70,7 @@ Get the lengths of the indiviudal elements in the ragged array
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{index}}{optionally only get lengths for a subset of persons. If
-\code{NULL}, return all lengths; if passed an [individual::Bitset]
+\code{NULL}, return all lengths; if passed an \link{Bitset}
 or integer vector, return lengths of arrays for those individuals.}
 }
 \if{html}{\out{</div>}}
@@ -83,16 +83,16 @@ or integer vector, return lengths of arrays for those individuals.}
 Queue an update for a variable. There are 4 types of variable update:
 
 \enumerate{
- \item{Subset update: }{The argument \code{index} represents a subset of the variable to
+\item{Subset update: }{The argument \code{index} represents a subset of the variable to
 update. The argument \code{values} should be a vector whose length matches the size of \code{index},
 which represents the new values for that subset.}
- \item{Subset fill: }{The argument \code{index} represents a subset of the variable to
+\item{Subset fill: }{The argument \code{index} represents a subset of the variable to
 update. The argument \code{values} should be a single number, which fills the specified subset.}
- \item{Variable reset: }{The index vector is set to \code{NULL} and the argument \code{values}
+\item{Variable reset: }{The index vector is set to \code{NULL} and the argument \code{values}
 replaces all of the current values in the simulation. \code{values} should be a vector
 whose length should match the size of the population, which fills all the variable values in
 the population}
- \item{Variable fill: }{The index vector is set to \code{NULL} and the argument \code{values}
+\item{Variable fill: }{The index vector is set to \code{NULL} and the argument \code{values}
 should be a single number, which fills all of the variable values in
 the population.}
 }
@@ -107,7 +107,7 @@ the population.}
 
 \item{\code{index}}{is the index at which to apply the change, use \code{NULL} for the
 fill options. If using indices, this may be either a vector of integers or
-an [individual::Bitset].}
+an \link{Bitset}.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/TargetedEvent.Rd
+++ b/man/TargetedEvent.Rd
@@ -29,9 +29,9 @@ This is useful for events which are triggered for a sub-population.
 \if{html}{\out{
 <details open><summary>Inherited methods</summary>
 <ul>
-<li><span class="pkg-link" data-pkg="individual" data-topic="Event" data-id=".process"><a href='../../individual/html/Event.html#method-Event-.process'><code>individual::Event$.process()</code></a></li>
-<li><span class="pkg-link" data-pkg="individual" data-topic="Event" data-id=".tick"><a href='../../individual/html/Event.html#method-Event-.tick'><code>individual::Event$.tick()</code></a></li>
-<li><span class="pkg-link" data-pkg="individual" data-topic="Event" data-id="add_listener"><a href='../../individual/html/Event.html#method-Event-add_listener'><code>individual::Event$add_listener()</code></a></li>
+<li><span class="pkg-link" data-pkg="individual" data-topic="Event" data-id=".process"><a href='../../individual/html/Event.html#method-Event-.process'><code>individual::Event$.process()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="individual" data-topic="Event" data-id=".tick"><a href='../../individual/html/Event.html#method-Event-.tick'><code>individual::Event$.tick()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="individual" data-topic="Event" data-id="add_listener"><a href='../../individual/html/Event.html#method-Event-add_listener'><code>individual::Event$add_listener()</code></a></span></li>
 </ul>
 </details>
 }}
@@ -65,7 +65,7 @@ Schedule this event to occur in the future.
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{target}}{the individuals to pass to the listener, this may be
-either a vector of integers or a \code{\link[individual]{Bitset}}.}
+either a vector of integers or a \link{Bitset}.}
 
 \item{\code{delay}}{the number of time steps to wait before triggering the event,
 can be a scalar in which case all targeted individuals are scheduled for
@@ -79,7 +79,7 @@ individual.}
 \if{html}{\out{<a id="method-TargetedEvent-get_scheduled"></a>}}
 \if{latex}{\out{\hypertarget{method-TargetedEvent-get_scheduled}{}}}
 \subsection{Method \code{get_scheduled()}}{
-Get the individuals who are scheduled as a \code{\link[individual]{Bitset}}.
+Get the individuals who are scheduled as a \link{Bitset}.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{TargetedEvent$get_scheduled()}\if{html}{\out{</div>}}
 }
@@ -98,7 +98,7 @@ Stop a future event from triggering for a subset of individuals.
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{target}}{the individuals to clear, this may be either a vector of integers or
-a \code{\link[individual]{Bitset}}.}
+a \link{Bitset}.}
 }
 \if{html}{\out{</div>}}
 }
@@ -107,7 +107,7 @@ a \code{\link[individual]{Bitset}}.}
 \if{html}{\out{<a id="method-TargetedEvent-queue_extend"></a>}}
 \if{latex}{\out{\hypertarget{method-TargetedEvent-queue_extend}{}}}
 \subsection{Method \code{queue_extend()}}{
-Extend the target size
+Extend the target size.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{TargetedEvent$queue_extend(n)}\if{html}{\out{</div>}}
 }
@@ -115,7 +115,7 @@ Extend the target size
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{n}}{the number of new elements to add to the index}
+\item{\code{n}}{the number of new elements to add to the index.}
 }
 \if{html}{\out{</div>}}
 }
@@ -124,7 +124,7 @@ Extend the target size
 \if{html}{\out{<a id="method-TargetedEvent-queue_extend_with_schedule"></a>}}
 \if{latex}{\out{\hypertarget{method-TargetedEvent-queue_extend_with_schedule}{}}}
 \subsection{Method \code{queue_extend_with_schedule()}}{
-Extend the target size and schedule for the new population
+Extend the target size and schedule for the new population.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{TargetedEvent$queue_extend_with_schedule(delays)}\if{html}{\out{</div>}}
 }
@@ -132,7 +132,7 @@ Extend the target size and schedule for the new population
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{delays}}{the delay for each new individual}
+\item{\code{delays}}{the delay for each new individual.}
 }
 \if{html}{\out{</div>}}
 }
@@ -141,7 +141,7 @@ Extend the target size and schedule for the new population
 \if{html}{\out{<a id="method-TargetedEvent-queue_shrink"></a>}}
 \if{latex}{\out{\hypertarget{method-TargetedEvent-queue_shrink}{}}}
 \subsection{Method \code{queue_shrink()}}{
-Shrink the targeted event
+Shrink the TargetedEvent.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{TargetedEvent$queue_shrink(index)}\if{html}{\out{</div>}}
 }
@@ -149,7 +149,7 @@ Shrink the targeted event
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{index}}{the individuals to remove from the event}
+\item{\code{index}}{the individuals to remove from the event.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/multi_probability_bernoulli_process.Rd
+++ b/man/multi_probability_bernoulli_process.Rd
@@ -20,7 +20,7 @@ a function which can be passed as a process to \code{\link{simulation_loop}}.
 }
 \description{
 Simulates a Bernoulli process where all individuals
-in a given source state \code{from} sample whether or not 
+in a given source state \code{from} sample whether or not
 to transition to destination state \code{to} with a
 individual probability specified by the \code{\link{DoubleVariable}}
 object \code{rate_variable}.

--- a/man/simulation_loop.Rd
+++ b/man/simulation_loop.Rd
@@ -21,7 +21,7 @@ simulation_loop(
 \item{timesteps}{the number of timesteps to simulate}
 }
 \description{
-Run a simulation where event listeners take precedence 
+Run a simulation where event listeners take precedence
 over processes for state changes.
 }
 \examples{


### PR DESCRIPTION
I think the errors coming up on CRAN were related to R switching to HTML5 (https://blog.r-project.org/2022/04/08/enhancements-to-html-documentation/) for validation in the newest version (see this issue https://github.com/r-lib/roxygen2/issues/1290). I updated the Roxygen2 version needed and set roxygen2 to use markdown syntax for parsing Rd files. I also simplified the offending parts of TargetedEvent to use markdown style links to help clear things up. Everything now passes on r-hub builders (using https://r-hub.github.io/rhub/reference/check_for_cran.html)