### PR TITLE
Fix broken pkgdown index.

### DIFF
--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -3,6 +3,11 @@ on:
     branches:
       - master
 
+  pull_request:
+    branches:
+      - dev 
+      - master
+
 name: pkgdown
 
 jobs:
@@ -40,7 +45,12 @@ jobs:
       - name: Install package
         run: R CMD INSTALL .
 
+      - name: Build site
+        run: |
+          Rscript -e 'pkgdown::build_site()'
+
       - name: Deploy package
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |
           git config --local user.email "actions@github.com"
           git config --local user.name "GitHub Actions"

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# individual 0.1.13
+
+  * Fixed the website generation.
+
 # individual 0.1.12
 
   * Simulation state can be saved and restored, allowing the simulation to be resumed.

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -15,6 +15,7 @@ reference:
 - title: "Events & Rendering"
   desc: "Classes for events and rendering output."
 - contents:
+  - EventBase
   - Event
   - TargetedEvent
   - Render
@@ -26,3 +27,5 @@ reference:
 - title: "Simulation"
 - contents:
   - simulation_loop
+  - checkpoint_state
+  - restore_state


### PR DESCRIPTION
I hadn't added the new types and functions to the pkgdown index, which broke the site rebuild. This didn't get caught by CI because pkgdown was only running on the master branch.

Added the missing index entries and changed the CI to run pkgdown everywhere. It only does the actual push when on the master branch.