### PR TITLE
Check if the schedule is empty before reading it.

### DIFF
--- a/inst/include/Event.h
+++ b/inst/include/Event.h
@@ -92,6 +92,9 @@ inline void Event::process(Rcpp::XPtr<listener_t> listener) {
 
 //' @title should first event fire on this timestep?
 inline bool Event::should_trigger() {
+    if (simple_schedule.empty()) {
+        return false;
+    }
     return *simple_schedule.begin() == get_time();
 }
 
@@ -179,7 +182,7 @@ inline TargetedEvent::TargetedEvent(size_t size)
 
 //' @title should first event fire on this timestep?
 inline bool TargetedEvent::should_trigger() {
-    if (targeted_schedule.begin() == targeted_schedule.end()) {
+    if (targeted_schedule.empty()) {
         return false;
     }
     return targeted_schedule.begin()->first == get_time();

--- a/tests/testthat/test-events.R
+++ b/tests/testthat/test-events.R
@@ -175,3 +175,16 @@ test_that("events are cleared when restored", {
   mockery::expect_args(listener, 1, t = 4)
   new_event$.tick()
 })
+
+test_that("empty event never triggers", {
+  event <- Event$new()
+  listener <- mockery::mock()
+  event$add_listener(listener)
+
+  for (i in seq(100)) {
+    event$.process()
+    event$.tick()
+  }
+
+  mockery::expect_called(listener, 0)
+})

--- a/tests/testthat/test-targetedevent.R
+++ b/tests/testthat/test-targetedevent.R
@@ -602,3 +602,16 @@ test_that("targeted events are cleared when restored", {
   new_event$.process()
   mockery::expect_called(listener, 1)
 })
+
+test_that("empty targeted event never triggers", {
+  event <- TargetedEvent$new(5)
+  listener <- mockery::mock()
+  event$add_listener(listener)
+
+  for (i in seq(100)) {
+    event$.process()
+    event$.tick()
+  }
+
+  mockery::expect_called(listener, 0)
+})


### PR DESCRIPTION
The `Event::should_trigger` method uses `.begin()` on the set of times at which it needs to fire to compare that value with the current tick. However it was missing a check in the case of an empty set. When that happens, `begin()` returns a pointer to uninitialized memory and we we reading garbage out of it. If that garbage happens to be equal to the current time step, the event would fire spuriously, even though it wasn't meant to.

The fix is straightforward: we just need to check if the set is empty before reading from the set. If it is empty then the event never triggers.