### PR TITLE
Optimize the bitset sampling algorithm.

### DIFF
--- a/tests/testthat/test-bitset.R
+++ b/tests/testthat/test-bitset.R
@@ -315,3 +315,46 @@ test_that("bitset filtering works when given empty bitset", {
   expect_equal(filter_bitset(b, f)$size(), 0)
   expect_equal(filter_bitset(b, integer(0))$size(), 0)
 })
+
+test_that("bitset sampling with extremes is correct", {
+  size <- 100
+  expect_equal(Bitset$new(size)$not()$sample(0)$size(), 0)
+  expect_equal(Bitset$new(size)$not()$sample(1)$size(), size)
+})
+
+test_that("bitset is evenly sampled", {
+  set.seed(123)
+
+  threshold <- 0.05
+  rates <- c(0.01, 0.1, 0.25, 0.5, 0.75, 0.9, 0.99)
+  size <- 100
+  N <- 1000
+
+  for (rate in rates) {
+    freqs <- rep(0, size)
+    for (i in seq(N)) {
+      b <- Bitset$new(size)$not()$sample(rate)
+      xs <- b$to_vector()
+      freqs[xs] <- freqs[xs] + 1
+    }
+    p <- t.test(freqs, mu=rate*N)$p.value
+    expect_gt(p, threshold)
+  }
+})
+
+test_that("bitset sampling has correctly distributed size", {
+  set.seed(123)
+
+  threshold <- 0.05
+  rates <- c(0.01, 0.1, 0.25, 0.5, 0.75, 0.9, 0.99)
+  size <- 100
+  N <- 1000
+
+  for (rate in rates) {
+    data <- sapply(1:N, function(i) {
+      Bitset$new(size)$not()$sample(rate)$size()
+    })
+    p <- t.test(data, mu=rate*size)$p.value
+    expect_gt(p, threshold)
+  }
+})

--- a/tests/testthat/test-bitset.R
+++ b/tests/testthat/test-bitset.R
@@ -337,7 +337,7 @@ test_that("bitset is evenly sampled", {
       xs <- b$to_vector()
       freqs[xs] <- freqs[xs] + 1
     }
-    p <- t.test(freqs, mu=rate*N)$p.value
+    p <- chisq.test(freqs)$p.value
     expect_gt(p, threshold)
   }
 })


### PR DESCRIPTION
The existing bitset sampling implementation works by using a binomial distribution to decide how many bits to keep, randomly chooses the indices of those bits, sorts the vector of indices and finally iterates over all the bits one by one to clear those not contained in the vector.

This can be very inefficient, in particular when sampling over large bit sets with a very low sampling rate. In that case, the list of indices to keep is roughly as large as the bitset itself, and sorting it requires O(nlog(n)) time, which ends up being significant.

Additionally, walking over every single bit, set or not, to be cleared or not, is pretty inefficient as well.

This commit optimizes the implementation through a few methods:
- Instead of sampling and sorting indices to keep, it randomly samples the size of the gaps between two succesful bernouilli trials. This was inspired by the [FastBernoulliTrial] class.
- When the sampling rate is higher than 1/2, it flips the sampling logic and uses the gaps between two unsuccessful trials, minimizing the number of loop iterations.
- Finally, in order to take full advantage of the gap lengths, it is able to quickly scan through the bitset to skip a given number of set bits, calling popcnt once per words rather than looking at each bit, and can clear entire ranges of bits at once by overwriting entire words, rather than masking bits one by one.

This implementation is faster than the previous one for the entire parameter space. The difference is most drastic for very low sampling rates where the new implementation is more than two orders of magnitude faster.

[FastBernoulliTrial]: https://searchfox.org/mozilla-central/rev/a6d25de0c706dbc072407ed5d339aaed1cab43b7/mfbt/FastBernoulliTrial.h