### PR TITLE
Avoid a copy on full vector replacement by using std::move.

### DIFF
--- a/inst/include/vector_variables.h
+++ b/inst/include/vector_variables.h
@@ -22,9 +22,9 @@ inline void vector_update(
     std::vector<A>& values
     ) {
     while(updates.size() > 0) {
-        const auto& update = updates.front();
-        const auto& new_values = update.first;
-        const auto& index = update.second;
+        auto& update = updates.front();
+        auto& new_values = update.first;
+        auto& index = update.second;
         
         auto vector_replacement = (index.size() == 0);
         auto value_fill = (new_values.size() == 1);
@@ -34,7 +34,7 @@ inline void vector_update(
             if (value_fill) {
                 std::fill(values.begin(), values.end(), new_values[0]);
             } else {
-                values = new_values;
+                values = std::move(new_values);
             }
         } else {
             if (value_fill) {


### PR DESCRIPTION
When a queued update replaces an entire variable, we can re-use the vector contained in the update by moving it over, instead of copying it.

This situation is actually pretty common in malariasimulation, where exponentially decaying variables are entirely overwritten at each time step. This change speeds up the simulation by about 5% for a 1M population.