### PR TITLE
Allow processes to be named.

### DIFF
--- a/tests/testthat/test-prefab.R
+++ b/tests/testthat/test-prefab.R
@@ -80,7 +80,7 @@ test_that("Multinomial process samples probabilities correctly", {
     rate = l_p,
     destination_probabilities = d_p
   )
-  individual:::execute_any_process(mult_process,1)
+  individual:::prepare_process(mult_process)(1)
   state$.update()
   state_new <- sapply(X = LETTERS[1:5],FUN = function(l){state$get_size_of(l)})
 
@@ -117,7 +117,7 @@ test_that("Overdispersed multinomial process samples probabilities correctly", {
     rate_variable = rate,
     destination_probabilities = d_p
   )
-  individual:::execute_any_process(mult_process,1)
+  individual:::prepare_process(mult_process)(1)
   state$.update()
 
   state_a <- state$get_index_of(values = "A")$to_vector()
@@ -145,7 +145,7 @@ test_that("Overdispersed multinomial process doesn't move people it shouldn't", 
     rate_variable = rate,
     destination_probabilities = d_p
   )
-  individual:::execute_any_process(mult_process,1)
+  individual:::prepare_process(mult_process)(1)
   state$.update()
 
   state_a <- state$get_index_of(values = "A")$to_vector()
@@ -172,7 +172,7 @@ test_that("Overdispersed bernoulli process works correctly", {
     rate_variable = rate 
   )
 
-  individual:::execute_any_process(multi_bp,1)
+  individual:::prepare_process(multi_bp)(1)
   state$.update()
 
   state_s <- state$get_index_of(values = "S")$to_vector()

--- a/tests/testthat/test-simulation-e2e.R
+++ b/tests/testthat/test-simulation-e2e.R
@@ -138,3 +138,37 @@ test_that("deterministic state & variable model works", {
 
   expect_mapequal(true_render, render$to_dataframe())
 })
+
+test_that("Can give names to processes", {
+  names <- NULL
+
+  simulation_loop(
+    processes = list(
+      foo = function(t) {
+        names <<- c(names, deparse(sys.call()[[1]]))
+      },
+      bar = function(t) {
+        names <<- c(names, deparse(sys.call()[[1]]))
+      }
+    ),
+    timesteps = 1)
+
+  expect_equal(names, c("foo", "bar"))
+})
+
+test_that("Can give two processes the same name", {
+  names <- NULL
+
+  simulation_loop(
+    processes = list(
+      foo = function(t) {
+        names <<- c(names, deparse(sys.call()[[1]]))
+      },
+      foo = function(t) {
+        names <<- c(names, deparse(sys.call()[[1]]))
+      }
+    ),
+    timesteps = 1)
+
+  expect_equal(names, c("foo", "foo"))
+})


### PR DESCRIPTION
Because of how R assigns names to stack frames, all processes in a typical individual simulation would end up being called `p`. This makes it difficult to interpret profiling results.

R uses the name of the variable the called function is bound to. By dynamically creating a variable with a chosen name and using `eval` to execute that variable, we can get the stack frame to show up with any desired name.

This uses this trick to allow the list of processes to be given names, and these names are used in the calls.

Below is a comparison of the before and after of looking at a malariasimulation profile. Instead of everything being grouped under a single `p` node, there are now distinct nodes for each process.

![image](https://github.com/mrc-ide/individual/assets/1489775/4782cedc-22cb-48e8-b17c-e535044e0c85)
![image](https://github.com/mrc-ide/individual/assets/1489775/35ab802f-ca4f-421d-a8b0-e56bea91e4ea)
