### PR TITLE
Make num_bits a constant expression.

### DIFF
--- a/inst/include/IterableBitset.h
+++ b/inst/include/IterableBitset.h
@@ -24,9 +24,11 @@ class IterableBitset;
 //' Each integer stores the existance of sizeof(A) * 8 elements in the set.
 template<class A>
 class IterableBitset {
+    static constexpr size_t num_bits = sizeof(A) * 8;
+
     size_t max_n;
     size_t n;
-    size_t num_bits;
+
     bool exists(size_t) const;
     void set(size_t);
     void unset(size_t);
@@ -203,7 +205,6 @@ inline typename IterableBitset<A>::const_iterator::reference IterableBitset<A>::
 
 template<class A>
 inline IterableBitset<A>::IterableBitset(size_t size) : max_n(size){
-    num_bits = sizeof(A) * 8;
     bitmap = std::vector<A>(size/num_bits + 1, 0);
     n = 0;
 }


### PR DESCRIPTION
The variable stores the number of bits per word and is used throughout the implementation to split a position into a word index and bit position in the word.

The value can be determined statically from the size of the template parameter and does not need to be stored as a field. Keeping it as a `constexpr` value allows the compiler to optimize operations that use it. In particular, since the value is always a power of two, any multiplication, division, and modulo operations by this value, which are quite common, can be turned into bit shifts or masks by a constant.

The performance impact of this change is quite small, but measurable, at around 2% for a 1M malariasimulation run, with no downside.