### PR TITLE
Allow only some processes to be named and not others.

### DIFF
--- a/R/simulation.R
+++ b/R/simulation.R
@@ -212,7 +212,7 @@ prepare_process <- function(p, name = NULL) {
     ptr <- p
     p <- function(t) execute_process(ptr, t)
   }
-  if (!is.null(name)) {
+  if (!is.null(name) && name != "") {
     env <- new.env()
     assign(name, p, envir=env)
     p <- function(t) eval(call(name, t), env)

--- a/tests/testthat/test-simulation-e2e.R
+++ b/tests/testthat/test-simulation-e2e.R
@@ -172,3 +172,20 @@ test_that("Can give two processes the same name", {
 
   expect_equal(names, c("foo", "foo"))
 })
+
+test_that("Can give a name to just one process", {
+  names <- NULL
+
+  simulation_loop(
+    processes = list(
+      function(t) {
+        names <<- c(names, deparse(sys.call()[[1]]))
+      },
+      foo = function(t) {
+        names <<- c(names, deparse(sys.call()[[1]]))
+      }
+    ),
+    timesteps = 1)
+
+  expect_equal(names[[2]], "foo")
+})


### PR DESCRIPTION
It was using `is.null` to detect unnamed processes, however in the case of a list of processes where some are named and some are not, the name is actually an empty string.