### PR TITLE
adding get_values to CategoricalVariable and making a new function for IntegrerVariable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,7 +65,7 @@ Suggests:
     testthat (>= 2.1.0),
     xml2,
     bench
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 VignetteBuilder: knitr
 LinkingTo:
   Rcpp,

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -125,8 +125,12 @@ categorical_variable_queue_shrink_bitset <- function(variable, index) {
     invisible(.Call(`_individual_categorical_variable_queue_shrink_bitset`, variable, index))
 }
 
-categorical_variable_get_values <- function(variable, index) {
-    .Call(`_individual_categorical_variable_get_values`, variable, index)
+categorical_variable_get_values <- function(variable) {
+    .Call(`_individual_categorical_variable_get_values`, variable)
+}
+
+categorical_variable_get_values_with_index <- function(variable, index) {
+    .Call(`_individual_categorical_variable_get_values_with_index`, variable, index)
 }
 
 create_double_variable <- function(values) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -125,6 +125,10 @@ categorical_variable_queue_shrink_bitset <- function(variable, index) {
     invisible(.Call(`_individual_categorical_variable_queue_shrink_bitset`, variable, index))
 }
 
+categorical_variable_get_values <- function(variable, index) {
+    .Call(`_individual_categorical_variable_get_values`, variable, index)
+}
+
 create_double_variable <- function(values) {
     .Call(`_individual_create_double_variable`, values)
 }
@@ -287,6 +291,10 @@ create_integer_variable <- function(values) {
 
 integer_variable_get_values <- function(variable) {
     .Call(`_individual_integer_variable_get_values`, variable)
+}
+
+integer_variable_get_modulo_differences <- function(variable, value, difference) {
+    .Call(`_individual_integer_variable_get_modulo_differences`, variable, value, difference)
 }
 
 integer_variable_get_values_at_index <- function(variable, index) {

--- a/R/categorical_variable.R
+++ b/R/categorical_variable.R
@@ -49,7 +49,6 @@ CategoricalVariable <- R6Class(
       stopifnot(is.finite(index))
       stopifnot(index > 0)
       if (length(index) == 0){
-        # temp_inds <- 
         results <- categorical_variable_get_values(self$.variable)
       }
       else{

--- a/R/categorical_variable.R
+++ b/R/categorical_variable.R
@@ -45,10 +45,16 @@ CategoricalVariable <- R6Class(
 
     #' @description return the value of the variable for the given individuals
     #' @param index the indices of individuals whose categories will be returned
-    get_values = function(index) {
+    get_values = function(index = NULL) {
       stopifnot(is.finite(index))
       stopifnot(index > 0)
-      results <- categorical_variable_get_values(self$.variable, index)
+      if (length(index) == 0){
+        # temp_inds <- 
+        results <- categorical_variable_get_values(self$.variable)
+      }
+      else{
+        results <- categorical_variable_get_values_with_index(self$.variable, index)
+      }
       return(results)
     },
 

--- a/R/categorical_variable.R
+++ b/R/categorical_variable.R
@@ -43,6 +43,15 @@ CategoricalVariable <- R6Class(
       categorical_variable_get_categories(self$.variable)
     },
 
+    #' @description return the value of the variable for the given individuals
+    #' @param index the indices of individuals whose categories will be returned
+    get_values = function(index) {
+      stopifnot(is.finite(index))
+      stopifnot(index > 0)
+      results <- categorical_variable_get_values(self$.variable, index)
+      return(results)
+    },
+
     #' @description queue an update for this variable
     #' @param value the new value
     #' @param index the indices of individuals whose value will be updated

--- a/R/integer_variable.R
+++ b/R/integer_variable.R
@@ -45,9 +45,7 @@ IntegerVariable <- R6Class(
     #' @param difference the difference to check, e.g. difference = 2 checks whether the
     #' difference is even
     get_modulo_differences = function(value, difference){
-      stopifnot(!is.null(value))
       stopifnot(is.finite(value))
-      stopifnot(!is.null(difference))
       stopifnot(is.finite(difference))
       integer_variable_get_modulo_differences(self$.variable, value, difference)
     },

--- a/R/integer_variable.R
+++ b/R/integer_variable.R
@@ -45,6 +45,10 @@ IntegerVariable <- R6Class(
     #' @param difference the difference to check, e.g. difference = 2 checks whether the
     #' difference is even
     get_modulo_differences = function(value, difference){
+      stopifnot(!is.null(value))
+      stopifnot(is.finite(value))
+      stopifnot(!is.null(difference))
+      stopifnot(is.finite(difference))
       integer_variable_get_modulo_differences(self$.variable, value, difference)
     },
 

--- a/R/integer_variable.R
+++ b/R/integer_variable.R
@@ -39,6 +39,15 @@ IntegerVariable <- R6Class(
 
     },
 
+    #' @description Return a vector of individuals with 0 modulo difference from input value
+    #' and the distance being compared
+    #' @param value the value to check
+    #' @param difference the difference to check, e.g. difference = 2 checks whether the
+    #' difference is even
+    get_modulo_differences = function(value, difference){
+      integer_variable_get_modulo_differences(self$.variable, value, difference)
+    },
+
     #' @description Return a \code{\link[individual]{Bitset}} for individuals with some subset of values.
     #' Either search for indices corresponding to values in \code{set}, or
     #' for indices corresponding to values in range \eqn{[a,b]}. Either \code{set}

--- a/inst/include/CategoricalVariable.h
+++ b/inst/include/CategoricalVariable.h
@@ -53,6 +53,7 @@ public:
     virtual size_t size() const override;
     virtual void update() override;
     virtual std::vector<std::string> get_values(const std::vector<size_t>&);
+    virtual std::vector<std::string> get_values();
 };
 
 
@@ -243,6 +244,27 @@ inline std::vector<std::string> CategoricalVariable::get_values(const std::vecto
                 Rcpp::stop(message.str());
             }
             if (indices.at(cat).find(index[i]) != indices.at(cat).end()) {
+                result[i] = cat;
+                break;
+            }
+        }
+    }
+    return result;
+}
+//' @title get values of full variable
+inline std::vector<std::string> CategoricalVariable::get_values(){
+    
+    // Generate empty output vector
+    auto result = std::vector<std::string>(size());
+    for(auto i = 0u; i < size(); ++i){
+        // Determine which category the individual is within
+        for (auto cat: categories) {
+            if (indices.find(cat) == indices.end()) {
+                std::stringstream message;
+                message << "unknown category: " << cat;
+                Rcpp::stop(message.str());
+            }
+            if (indices.at(cat).find(i) != indices.at(cat).end()) {
                 result[i] = cat;
                 break;
             }

--- a/inst/include/CategoricalVariable.h
+++ b/inst/include/CategoricalVariable.h
@@ -52,6 +52,7 @@ public:
     virtual void resize() override;
     virtual size_t size() const override;
     virtual void update() override;
+    virtual std::vector<std::string> get_values(const std::vector<size_t>&);
 };
 
 
@@ -228,5 +229,25 @@ inline size_t CategoricalVariable::size() const {
 inline const std::vector<std::string>& CategoricalVariable::get_categories() const {
     return categories;
 }
-
+//' @title get values at index given by a vector
+inline std::vector<std::string> CategoricalVariable::get_values(const std::vector<size_t>& index){
+    
+    // Generate empty output vector
+    auto result = std::vector<std::string>(index.size());
+    for (auto i = 0u; i < index.size(); ++i) {
+        // Determine which category the individual is within
+        for (auto cat: categories) {
+            if (indices.find(cat) == indices.end()) {
+                std::stringstream message;
+                message << "unknown category: " << cat;
+                Rcpp::stop(message.str());
+            }
+            if (indices.at(cat).find(index[i]) != indices.at(cat).end()) {
+                result[i] = cat;
+                break;
+            }
+        }
+    }
+    return result;
+}
 #endif /* INST_INCLUDE_CATEGORICAL_VARIABLE_H_ */

--- a/inst/include/IntegerVariable.h
+++ b/inst/include/IntegerVariable.h
@@ -30,6 +30,7 @@ struct IntegerVariable : public NumericVariable<int> {
     virtual size_t get_size_of_set(const std::vector<int>&) const;
     virtual size_t get_size_of_set(const int) const;
     virtual size_t get_size_of_range(const int, const int) const;
+    virtual individual_index_t get_modulo_differences(const int, const int) const;
 };
 
 inline IntegerVariable::IntegerVariable(const std::vector<int>& values)
@@ -59,6 +60,23 @@ inline individual_index_t IntegerVariable::get_index_of_set(
     auto result = individual_index_t(size());
     for (auto i = 0u; i < values.size(); ++i) {
         if ( values[i] == value ) {
+            result.insert(i);
+        }
+    }
+    
+    return result;
+}
+
+//' @title return bitset giving index of individuals whose difference between
+// the current value and the queried value is a multiple of the queried difference
+inline individual_index_t IntegerVariable::get_modulo_differences(
+    const int value,
+    const int difference
+) const {
+    
+    auto result = individual_index_t(size());
+    for (auto i = 0u; i < values.size(); ++i) {
+        if ( (values[i] - value) % difference == 0 ) {
             result.insert(i);
         }
     }

--- a/inst/include/individual_types.h
+++ b/inst/include/individual_types.h
@@ -10,7 +10,6 @@
 
 #include <Rcpp.h>
 #include "CategoricalVariable.h"
-// #include "FunctionalVariable.h"
 #include "IntegerVariable.h"
 #include "DoubleVariable.h"
 #include "RaggedInteger.h"

--- a/inst/include/individual_types.h
+++ b/inst/include/individual_types.h
@@ -10,6 +10,7 @@
 
 #include <Rcpp.h>
 #include "CategoricalVariable.h"
+// #include "FunctionalVariable.h"
 #include "IntegerVariable.h"
 #include "DoubleVariable.h"
 #include "RaggedInteger.h"

--- a/man/CategoricalVariable.Rd
+++ b/man/CategoricalVariable.Rd
@@ -17,6 +17,7 @@ if possible because certain operations will be faster.
 \item \href{#method-CategoricalVariable-get_index_of}{\code{CategoricalVariable$get_index_of()}}
 \item \href{#method-CategoricalVariable-get_size_of}{\code{CategoricalVariable$get_size_of()}}
 \item \href{#method-CategoricalVariable-get_categories}{\code{CategoricalVariable$get_categories()}}
+\item \href{#method-CategoricalVariable-get_values}{\code{CategoricalVariable$get_values()}}
 \item \href{#method-CategoricalVariable-queue_update}{\code{CategoricalVariable$queue_update()}}
 \item \href{#method-CategoricalVariable-queue_extend}{\code{CategoricalVariable$queue_extend()}}
 \item \href{#method-CategoricalVariable-queue_shrink}{\code{CategoricalVariable$queue_shrink()}}
@@ -94,6 +95,23 @@ unordered storage type.
 \if{html}{\out{<div class="r">}}\preformatted{CategoricalVariable$get_categories()}\if{html}{\out{</div>}}
 }
 
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-CategoricalVariable-get_values"></a>}}
+\if{latex}{\out{\hypertarget{method-CategoricalVariable-get_values}{}}}
+\subsection{Method \code{get_values()}}{
+return the value of the variable for the given individuals
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{CategoricalVariable$get_values(index = NULL)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{index}}{the indices of individuals whose categories will be returned}
+}
+\if{html}{\out{</div>}}
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-CategoricalVariable-queue_update"></a>}}

--- a/man/IntegerVariable.Rd
+++ b/man/IntegerVariable.Rd
@@ -15,6 +15,7 @@ household or age bin.
 \itemize{
 \item \href{#method-IntegerVariable-new}{\code{IntegerVariable$new()}}
 \item \href{#method-IntegerVariable-get_values}{\code{IntegerVariable$get_values()}}
+\item \href{#method-IntegerVariable-get_modulo_differences}{\code{IntegerVariable$get_modulo_differences()}}
 \item \href{#method-IntegerVariable-get_index_of}{\code{IntegerVariable$get_index_of()}}
 \item \href{#method-IntegerVariable-get_size_of}{\code{IntegerVariable$get_size_of()}}
 \item \href{#method-IntegerVariable-queue_update}{\code{IntegerVariable$queue_update()}}
@@ -60,6 +61,27 @@ Get the variable values.
 \item{\code{index}}{optionally return a subset of the variable vector. If
 \code{NULL}, return all values; if passed a \code{\link[individual]{Bitset}}
 or integer vector, return values of those individuals.}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-IntegerVariable-get_modulo_differences"></a>}}
+\if{latex}{\out{\hypertarget{method-IntegerVariable-get_modulo_differences}{}}}
+\subsection{Method \code{get_modulo_differences()}}{
+Return a vector of individuals with 0 modulo difference from input value
+and the distance being compared
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{IntegerVariable$get_modulo_differences(value, difference)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{value}}{the value to check}
+
+\item{\code{difference}}{the difference to check, e.g. difference = 2 checks whether the
+difference is even}
 }
 \if{html}{\out{</div>}}
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -363,14 +363,25 @@ BEGIN_RCPP
 END_RCPP
 }
 // categorical_variable_get_values
-std::vector<std::string> categorical_variable_get_values(Rcpp::XPtr<CategoricalVariable> variable, std::vector<size_t>& index);
-RcppExport SEXP _individual_categorical_variable_get_values(SEXP variableSEXP, SEXP indexSEXP) {
+std::vector<std::string> categorical_variable_get_values(Rcpp::XPtr<CategoricalVariable> variable);
+RcppExport SEXP _individual_categorical_variable_get_values(SEXP variableSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<CategoricalVariable> >::type variable(variableSEXP);
+    rcpp_result_gen = Rcpp::wrap(categorical_variable_get_values(variable));
+    return rcpp_result_gen;
+END_RCPP
+}
+// categorical_variable_get_values_with_index
+std::vector<std::string> categorical_variable_get_values_with_index(Rcpp::XPtr<CategoricalVariable> variable, std::vector<size_t>& index);
+RcppExport SEXP _individual_categorical_variable_get_values_with_index(SEXP variableSEXP, SEXP indexSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::XPtr<CategoricalVariable> >::type variable(variableSEXP);
     Rcpp::traits::input_parameter< std::vector<size_t>& >::type index(indexSEXP);
-    rcpp_result_gen = Rcpp::wrap(categorical_variable_get_values(variable, index));
+    rcpp_result_gen = Rcpp::wrap(categorical_variable_get_values_with_index(variable, index));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1533,7 +1544,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_individual_categorical_variable_queue_extend", (DL_FUNC) &_individual_categorical_variable_queue_extend, 2},
     {"_individual_categorical_variable_queue_shrink", (DL_FUNC) &_individual_categorical_variable_queue_shrink, 2},
     {"_individual_categorical_variable_queue_shrink_bitset", (DL_FUNC) &_individual_categorical_variable_queue_shrink_bitset, 2},
-    {"_individual_categorical_variable_get_values", (DL_FUNC) &_individual_categorical_variable_get_values, 2},
+    {"_individual_categorical_variable_get_values", (DL_FUNC) &_individual_categorical_variable_get_values, 1},
+    {"_individual_categorical_variable_get_values_with_index", (DL_FUNC) &_individual_categorical_variable_get_values_with_index, 2},
     {"_individual_dummy", (DL_FUNC) &_individual_dummy, 0},
     {"_individual_create_double_variable", (DL_FUNC) &_individual_create_double_variable, 1},
     {"_individual_double_variable_get_values", (DL_FUNC) &_individual_double_variable_get_values, 1},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -362,6 +362,18 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
+// categorical_variable_get_values
+std::vector<std::string> categorical_variable_get_values(Rcpp::XPtr<CategoricalVariable> variable, std::vector<size_t>& index);
+RcppExport SEXP _individual_categorical_variable_get_values(SEXP variableSEXP, SEXP indexSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<CategoricalVariable> >::type variable(variableSEXP);
+    Rcpp::traits::input_parameter< std::vector<size_t>& >::type index(indexSEXP);
+    rcpp_result_gen = Rcpp::wrap(categorical_variable_get_values(variable, index));
+    return rcpp_result_gen;
+END_RCPP
+}
 // dummy
 void dummy();
 static SEXP _individual_dummy_try() {
@@ -851,6 +863,19 @@ BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::XPtr<IntegerVariable> >::type variable(variableSEXP);
     rcpp_result_gen = Rcpp::wrap(integer_variable_get_values(variable));
+    return rcpp_result_gen;
+END_RCPP
+}
+// integer_variable_get_modulo_differences
+individual_index_t integer_variable_get_modulo_differences(Rcpp::XPtr<IntegerVariable> variable, const int value, const int difference);
+RcppExport SEXP _individual_integer_variable_get_modulo_differences(SEXP variableSEXP, SEXP valueSEXP, SEXP differenceSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<IntegerVariable> >::type variable(variableSEXP);
+    Rcpp::traits::input_parameter< const int >::type value(valueSEXP);
+    Rcpp::traits::input_parameter< const int >::type difference(differenceSEXP);
+    rcpp_result_gen = Rcpp::wrap(integer_variable_get_modulo_differences(variable, value, difference));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1508,6 +1533,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_individual_categorical_variable_queue_extend", (DL_FUNC) &_individual_categorical_variable_queue_extend, 2},
     {"_individual_categorical_variable_queue_shrink", (DL_FUNC) &_individual_categorical_variable_queue_shrink, 2},
     {"_individual_categorical_variable_queue_shrink_bitset", (DL_FUNC) &_individual_categorical_variable_queue_shrink_bitset, 2},
+    {"_individual_categorical_variable_get_values", (DL_FUNC) &_individual_categorical_variable_get_values, 2},
     {"_individual_dummy", (DL_FUNC) &_individual_dummy, 0},
     {"_individual_create_double_variable", (DL_FUNC) &_individual_create_double_variable, 1},
     {"_individual_double_variable_get_values", (DL_FUNC) &_individual_double_variable_get_values, 1},
@@ -1550,6 +1576,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_individual_process_targeted_listener", (DL_FUNC) &_individual_process_targeted_listener, 3},
     {"_individual_create_integer_variable", (DL_FUNC) &_individual_create_integer_variable, 1},
     {"_individual_integer_variable_get_values", (DL_FUNC) &_individual_integer_variable_get_values, 1},
+    {"_individual_integer_variable_get_modulo_differences", (DL_FUNC) &_individual_integer_variable_get_modulo_differences, 3},
     {"_individual_integer_variable_get_values_at_index", (DL_FUNC) &_individual_integer_variable_get_values_at_index, 2},
     {"_individual_integer_variable_get_values_at_index_vector", (DL_FUNC) &_individual_integer_variable_get_values_at_index_vector, 2},
     {"_individual_integer_variable_get_index_of_set_vector", (DL_FUNC) &_individual_integer_variable_get_index_of_set_vector, 2},

--- a/src/categorical_variable.cpp
+++ b/src/categorical_variable.cpp
@@ -103,3 +103,14 @@ void categorical_variable_queue_shrink_bitset(
     ) {
     variable->queue_shrink(*index);
 }
+
+//[[Rcpp::export]]
+std::vector<std::string> categorical_variable_get_values(
+    Rcpp::XPtr<CategoricalVariable> variable,
+    std::vector<size_t>& index
+    ) {
+    decrement(index);
+    std::vector<std::string> results;
+    results = variable->get_values(index);
+    return results;
+}

--- a/src/categorical_variable.cpp
+++ b/src/categorical_variable.cpp
@@ -106,6 +106,14 @@ void categorical_variable_queue_shrink_bitset(
 
 //[[Rcpp::export]]
 std::vector<std::string> categorical_variable_get_values(
+    Rcpp::XPtr<CategoricalVariable> variable
+    ) {
+    std::vector<std::string> results;
+    results = variable->get_values();
+    return results;
+}
+//[[Rcpp::export]]
+std::vector<std::string> categorical_variable_get_values_with_index(
     Rcpp::XPtr<CategoricalVariable> variable,
     std::vector<size_t>& index
     ) {

--- a/src/integer_variable.cpp
+++ b/src/integer_variable.cpp
@@ -27,6 +27,15 @@ const std::vector<int>& integer_variable_get_values(
 }
 
 //[[Rcpp::export]]
+individual_index_t integer_variable_get_modulo_differences(
+    Rcpp::XPtr<IntegerVariable> variable,
+    const int value,
+    const int difference
+) {
+    return variable->get_modulo_differences(value, difference);
+}
+
+//[[Rcpp::export]]
 std::vector<int> integer_variable_get_values_at_index(
     Rcpp::XPtr<IntegerVariable> variable,
     Rcpp::XPtr<individual_index_t> index

--- a/tests/testthat/test-categoricalvariable-resize.R
+++ b/tests/testthat/test-categoricalvariable-resize.R
@@ -10,6 +10,16 @@ test_that("CategoricalVariable extending variables returns the new values", {
   expect_equal(x$get_index_of('R')$to_vector(), 13)
 })
 
+test_that("CategoricalVariables returns correct values after resize", {
+  categories = c('S', 'S', 'R', 'I')
+  
+  # standard case
+  x <- CategoricalVariable$new(SIR, categories)
+  x$queue_extend(values = rep('I', 2))
+  x$.resize()
+  expect_equal(x$get_values(seq(1:length(c(categories, rep('I', 2))))), c(categories, rep('I', 2)))
+})
+
 test_that("CategoricalVariable shrinking variables removes values (bitset)", {
   x <- CategoricalVariable$new(SIR, rep('S', 10))
   x$queue_shrink(index = Bitset$new(10)$insert(1:5))

--- a/tests/testthat/test-categoricalvariable.R
+++ b/tests/testthat/test-categoricalvariable.R
@@ -8,6 +8,29 @@ test_that("Creating CategoricalVariables errors with bad input", {
   expect_error(CategoricalVariable$new(categories = character(0), initial_values = letters[1:2]))
 })
 
+test_that("CategoricalVariables returns correct values", {
+  categories = c('S', 'S', 'R', 'I')
+  
+  # standard case
+  variable <- CategoricalVariable$new(SIR, categories)
+  expect_equal(variable$get_values(seq(1,4)), categories)
+  expect_equal(variable$get_values(c(2,4)), c(categories[c(2,4)]))
+  
+  # empty case
+  variable <- CategoricalVariable$new(SIR, character(0))
+  expect_equal(variable$get_values() , character(0))
+})
+
+test_that("CategoricalVariables returns correct values after update", {
+  categories = c('S', 'S', 'R', 'I')
+  
+  # standard case
+  variable <- CategoricalVariable$new(SIR, categories)
+  variable$queue_update('I', 1)
+  variable$.update()
+  expect_equal(variable$get_values(seq(1,4)), c('I', 'S', 'R', 'I'))
+})
+
 test_that("CategoricalVariable get index works returns correct values", {
   size <- 10
   state <- CategoricalVariable$new(SIR, rep('S', size))

--- a/tests/testthat/test-integervariable.R
+++ b/tests/testthat/test-integervariable.R
@@ -23,6 +23,29 @@ test_that("IntegerVariable get values returns correct values without index", {
   expect_equal(variable$get_values(c(1, 1, 2, 2)), c(1, 1, 2, 2))
 })
 
+test_that("IntegerVariables returns correct modulo differences", {
+  size <- 10
+  variable <- IntegerVariable$new(seq_len(size))
+  vals <- variable$get_values()
+  x <- 3
+  d <- 3
+  expected_modulo_differences <- c()
+  ind <- 1
+  for(i in seq_len(size)){
+    val <- vals[i]
+    if ((val - x) %% d == 0){
+      expected_modulo_differences[ind] <- i - 1
+      ind <- ind + 1
+    }
+  }
+  expect_equal(variable$get_modulo_differences(x, d), expected_modulo_differences)
+})
+
+test_that("IntegerVariables errors for invalid modulo differences", {
+  expect_error(variable$get_modulo_differences())
+  expect_error(variable$get_modulo_differences("a", 1))
+  expect_error(variable$get_modulo_differences(1, "1"))
+})
 test_that("IntegerVariable get values returns correct values with vector index", {
   size <- 10
   variable <- IntegerVariable$new(seq_len(size))


### PR DESCRIPTION
This PR adds the get_values function to variables of the type CategoricalVariable and a new function called get_modulo_differences to variables of the type IntegerVariable.

get_modulo_differences is designed to be used in future work where individuals within host dynamics may only want to be updated every N timesteps.

get_values has been added to CategoricalVariable to be able to follow the changes that occur for a given individual more easily.