### PR TITLE
R 4.6 compatibility updates:

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: individual
 Title: Framework for Specifying and Simulating Individual Based Models
-Version: 0.1.18
+Version: 0.1.19
 Authors@R: c(
   person(
     given = "Giovanni",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# individual 0.1.19
+
+  * add support for R 4.6 (C++20 fixes)
+  * fix small bug in bernoulli sampling
+
 # individual 0.1.18
 
   * add $get_values to CategoricalVariable

--- a/inst/include/IterableBitset.h
+++ b/inst/include/IterableBitset.h
@@ -34,23 +34,21 @@ class IterableBitset {
     void unset(size_t);
     std::vector<A> bitmap;
 public:
-    using allocator_type = std::allocator<size_t>;
-    using value_type = allocator_type::value_type;
-    using reference = allocator_type::reference;
-    using const_reference = allocator_type::const_reference;
-    using difference_type = allocator_type::difference_type;
-    using size_type = allocator_type::size_type;
-    using input_iterator_type = std::iterator<std::input_iterator_tag, size_t>;
+    using value_type = size_t;
+    using reference = size_t&;
+    using const_reference = const size_t&;
+    using difference_type = std::ptrdiff_t;
+    using size_type = std::size_t;
 
     class const_iterator {
     private:
         const IterableBitset& index;
         size_t p;
     public:
-        using difference_type = allocator_type::difference_type;
-        using value_type = allocator_type::value_type;
-        using reference = allocator_type::reference;
-        using pointer = const allocator_type::pointer;
+        using difference_type = std::ptrdiff_t;
+        using value_type = size_t;
+        using reference = size_t&;
+        using pointer = const size_t*;
         using iterator_category = std::forward_iterator_tag;
 
         const_iterator(const IterableBitset&, size_t);
@@ -608,7 +606,7 @@ struct fast_bernouilli {
             // `probability_log` rounded to zero, which we can't inverse. Treat
             // these probabilties the same as 0.
             if (probability_log == 0.0) {
-                probability = 0.;
+                this->probability = 0.;
             } else {
                 inverse_log = 1 / probability_log;
             }
@@ -641,7 +639,7 @@ struct fast_bernouilli {
 
     private:
         double probability;
-        double inverse_log;
+        double inverse_log = 0.0;
 };
 
 //' Sample values from the bitset.

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,1 +1,0 @@
-CXX_STD = CXX14

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -424,7 +424,7 @@ RcppExport SEXP _individual_dummy() {
     if (rcpp_isError_gen) {
         SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
         UNPROTECT(1);
-        Rf_error("%s", CHAR(rcpp_msgSEXP_gen));
+        (Rf_error)("%s", CHAR(rcpp_msgSEXP_gen));
     }
     UNPROTECT(1);
     return rcpp_result_gen;

--- a/src/bitset.cpp
+++ b/src/bitset.cpp
@@ -179,7 +179,7 @@ Rcpp::XPtr<individual_index_t> filter_bitset_logical(
     const Rcpp::XPtr<individual_index_t> bitset,
     Rcpp::LogicalVector other
     ) {
-    if (bitset->size() != other.size()) {
+    if (bitset->size() != static_cast<size_t>(other.size())) {
         Rcpp::stop("vector of logicals must equal the size of the bitset");
     }
 


### PR DESCRIPTION
 * Make IterableBitset iterator compatible with C++20
 * Fix cheeky bug in `fast_bernoulli` where the probability member is unintentionally shadowed
 * Fix compiler warnings for fast bernoulli and (un)signed size comparisons in bitset api